### PR TITLE
Support storage and migrations using custom thenables

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,9 +53,9 @@ var Migrator = module.exports = redefine.Class({
             })
             .then(function (executed) {
               if (!executed && (options.method === 'up')) {
-                return self.storage.logMigration(migration.file);
+                return Bluebird.resolve(self.storage.logMigration(migration.file));
               } else if (options.method === 'down') {
-                return self.storage.unlogMigration(migration.file);
+                return Bluebird.resolve(self.storage.unlogMigration(migration.file));
               }
             });
         });
@@ -63,7 +63,7 @@ var Migrator = module.exports = redefine.Class({
   },
 
   executed: function () {
-    return this.storage.executed().bind(this).map(function (file) {
+    return Bluebird.resolve(this.storage.executed()).bind(this).map(function (file) {
       return new Migration(file);
     });
   },

--- a/test/helper.js
+++ b/test/helper.js
@@ -50,5 +50,29 @@ var helper = module.exports = {
 
       resolve(names);
     });
+  },
+
+  wrapStorageAsCustomThenable: function(storage) {
+
+    return {
+      logMigration: function(migration) {
+        return helper._convertPromiseToThenable(storage.logMigration(migration));
+      },
+      unlogMigration: function(migration) {
+        return helper._convertPromiseToThenable(storage.unlogMigration(migration));
+      },
+      executed: function() {
+        return helper._convertPromiseToThenable(storage.executed());
+      }
+    };
+  },
+
+  _convertPromiseToThenable: function(promise) {
+    return {
+      then: function(onFulfilled, onRejected) {
+        //note don't return anything!
+        promise.then(onFulfilled, onRejected);
+      }
+    };
   }
 };

--- a/test/index/down.test.js
+++ b/test/index/down.test.js
@@ -267,5 +267,42 @@ describe('Migrator', function () {
         });
       });
     });
+
+    describe('when storage returns a thenable', function() {
+
+      beforeEach(function() {
+
+        //a migration has been executed already...
+        return this.migrator.execute({
+          migrations: [ this.migrationNames[0] ],
+          method:     'up'
+        }).bind(this).then(function () {
+          return this.migrator.executed();
+        }).then(function (migrations) {
+          expect(migrations).to.have.length(1);
+        }).then(function () {
+
+          //storage returns a thenable
+          this.migrator.storage = helper.wrapStorageAsCustomThenable(this.migrator.storage);
+          
+          return this.migrator.down();
+        }).then(function (migrations) {
+          this.migrations = migrations;
+        });
+
+      });
+
+      it('returns 1 item', function () {
+        expect(this.migrations).to.have.length(1);
+        expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+      });
+
+      it('removes the reverted migrations from the storage', function () {
+        return this.migrator.executed().then(function (migrations) {
+          expect(migrations).to.have.length(0);
+        });
+      });
+
+    });
   });
 });

--- a/test/index/executed.test.js
+++ b/test/index/executed.test.js
@@ -87,5 +87,32 @@ describe('Migrator', function () {
         expect(this.migrations[2].file).to.equal(this.migrationNames[2] + '.js');
       });
     });
+
+    describe('when storage returns a thenable', function() {
+
+      beforeEach(function() {
+  
+        //1 migration has been executed already
+        return this.migrator.execute({
+          migrations: [ this.migrationNames[0] ],
+          method:     'up'
+        }).bind(this).then(function () {
+          this.migrator.storage = helper.wrapStorageAsCustomThenable(this.migrator.storage);          
+          return this.migrator.executed();
+        }).then(function (migrations) {
+          this.migrations = migrations;
+        });
+      });
+
+      it('returns an array', function () {
+        expect(this.migrations).to.be.an(Array);
+      });
+
+      it('returns 1 items', function () {
+        expect(this.migrations).to.have.length(1);
+        expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+      });
+    });
+
   });
 });

--- a/test/index/pending.test.js
+++ b/test/index/pending.test.js
@@ -71,5 +71,36 @@ describe('Migrator', function () {
         });
       });
     });
+
+    describe('when storage returns a thenable', function () {
+      beforeEach(function () {
+
+        //a migration has been executed already
+        return this.migrator.execute({
+          migrations: [ this.migrationNames[0] ],
+          method:     'up'
+        }).bind(this).then(function () {
+
+          //storage returns a thenable
+          this.migrator.storage = helper.wrapStorageAsCustomThenable(this.migrator.storage);
+          
+          return this.migrator.pending();
+        }).then(function (migrations) {
+          this.migrations = migrations;
+        });
+      });
+
+      it('returns only 2 items', function () {
+        expect(this.migrations).to.have.length(2);
+      });
+
+      it('returns only the migrations that have not been run yet', function () {
+        var self = this;
+
+        this.migrationNames.slice(1).forEach(function (migrationName, i) {
+          expect(self.migrations[i].file).to.equal(migrationName + '.js');
+        });
+      });
+    });
   });
 });

--- a/test/index/up.test.js
+++ b/test/index/up.test.js
@@ -234,5 +234,43 @@ describe('Migrator', function () {
         });
       });
     });
+
+    describe('when storage returns a thenable', function () {
+      beforeEach(function () {
+
+        //one migration has been executed already
+        return this.migrator.execute({
+          migrations: [ this.migrationNames[0] ],
+          method:     'up'
+        }).bind(this).then(function () {
+
+          //storage returns a thenable
+          this.migrator.storage = helper.wrapStorageAsCustomThenable(this.migrator.storage);
+          
+          return this.migrator.up();
+        }).then(function (migrations) {
+          this.migrations = migrations;
+        });
+      });
+
+      it('returns only 2 items', function () {
+        expect(this.migrations).to.have.length(2);
+      });
+
+      it('returns only the migrations that have not been run yet', function () {
+        var self = this;
+
+        this.migrationNames.slice(1).forEach(function (migrationName, i) {
+          expect(self.migrations[i].file).to.equal(migrationName + '.js');
+        });
+      });
+
+      it('adds the two missing migrations to the storage', function () {
+        return this.migrator.executed().then(function (migrations) {
+          expect(migrations).to.have.length(3);
+        });
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Don't require storage and migration implementations to return Bluebird
promises - any object with a then(...) method should do.
