### PR TITLE
Fix sequelize resolution for global installation

### DIFF
--- a/lib/storages/sequelize.js
+++ b/lib/storages/sequelize.js
@@ -4,7 +4,8 @@ var _         = require('lodash');
 var Bluebird  = require('bluebird');
 var path      = require('path');
 var redefine  = require('redefine');
-var Sequelize = require('sequelize');
+var resolve   = require('resolve').sync;
+var Sequelize = require(resolve('sequelize', { basedir: process.cwd() }));
 
 /**
  * Sequelize storage


### PR DESCRIPTION
Previously it was not possible to install umzug as a dependency of a
globally installed package while indirectly using the sequelize storage.
