### PR TITLE
Update sequelize storage to sort results.

### DIFF
--- a/lib/storages/sequelize.js
+++ b/lib/storages/sequelize.js
@@ -119,7 +119,7 @@ module.exports = redefine.Class({
     return this._model()
       .sync()
       .then(function(Model) {
-        return Model.findAll();
+        return Model.findAll({ order: [ [ self.options.storageOptions.columnName, 'ASC' ] ] });
       })
       .then(function(migrations) {
         return migrations.map(function(migration) {


### PR DESCRIPTION
When the number of migrations start to increase and SequelizeMeta is persisted in a proper db, in my case postgresql, the table can start to be broken up across pages. This causes the results of findAll to be potentially out of order.
I'm using [Sequelize-cli](https://github.com/sequelize/cli) to build my migrations so all my scripts are prefixed with a timestamp making this default perfect, but if this doesn't work in all cases it would be extend this to use a storage option and update [Sequelize-cli](https://github.com/sequelize/cli) to use this sort by default.