### PR TITLE
Added restrictions to `up|down({ to: ... })`; fixes #36

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,6 +155,25 @@ var Umzug = module.exports = redefine.Class({
     } else {
       return this.pending().bind(this)
         .then(function (migrations) {
+          var result = Bluebird.resolve().bind(this);
+
+          if (options.to) {
+            result = result
+              .then(function () {
+                // There must be a migration matching to options.to...
+                return this._findMigration(options.to);
+              })
+              .then(function (migration) {
+                // ... and it must be pending.
+                return this._isPending(migration);
+              });
+          }
+
+          return result.then(function () {
+            return Bluebird.resolve(migrations)
+          });
+        })
+        .then(function (migrations) {
           return this._findMigrationsUntilMatch(options.to, migrations);
         })
         .then(function (migrationFiles) {
@@ -198,6 +217,25 @@ var Umzug = module.exports = redefine.Class({
       return this.execute({ migrations: options.migrations, method: 'down' });
     } else {
       return getExecuted().bind(this)
+        .then(function (migrations) {
+          var result = Bluebird.resolve().bind(this);
+
+          if (options.to) {
+            result = result
+              .then(function () {
+                // There must be a migration matching to options.to...
+                return this._findMigration(options.to);
+              })
+              .then(function (migration) {
+                // ... and it must be executed.
+                return this._wasExecuted(migration);
+              });
+          }
+
+          return result.then(function () {
+            return Bluebird.resolve(migrations)
+          });
+        })
         .then(function (migrations) {
           return this._findMigrationsUntilMatch(options.to, migrations);
         })

--- a/test/index/down.test.js
+++ b/test/index/down.test.js
@@ -118,6 +118,32 @@ describe('Umzug', function () {
             expect(migrations[0].file).to.equal(this.migrationNames[0] + '.js');
           });
         });
+
+        describe('that does not match a migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug.down({ to: '123-asdasd' }).then(function () {
+              return Bluebird.reject('We should not end up here...');
+            }, function (err) {
+              expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+            });
+          });
+        });
+
+        describe('that does not match an executed migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({ migrations: this.migrationNames, method: 'down' })
+              .bind(this)
+              .then(function () {
+                return this.umzug.down({ to: this.migrationNames[1] });
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration was not executed: 2-migration.js');
+              });
+          });
+        });
       });
     });
 

--- a/test/index/up.test.js
+++ b/test/index/up.test.js
@@ -102,6 +102,32 @@ describe('Umzug', function () {
             expect(migrationFiles).to.not.contain(this.migrationNames[2]);
           });
       });
+
+      describe('that does not match a migration', function () {
+        it('rejects the promise', function () {
+          return this.umzug.up({ to: '123-asdasd' }).then(function () {
+            return Bluebird.reject('We should not end up here...');
+          }, function (err) {
+            expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+          });
+        });
+      });
+
+      describe('that does not match a pending migration', function () {
+        it('rejects the promise', function () {
+          return this.umzug
+            .execute({ migrations: this.migrationNames, method: 'up' })
+            .bind(this)
+            .then(function () {
+              return this.umzug.up({ to: this.migrationNames[1] });
+            })
+            .then(function () {
+              return Bluebird.reject('We should not end up here...');
+            }, function (err) {
+              expect(err.message).to.equal('Migration is not pending: 2-migration.js');
+            });
+        });
+      });
     });
 
     describe('when called with a string', function () {


### PR DESCRIPTION
- Check that there is a migration that matches to `to` parameter.
- Check that the migration is pending/executed.