### PR TITLE
Squashed migrations; #39

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _        = require('lodash');
 var _path    = require('path');
 var Bluebird = require('bluebird');
 var helper   = require('./helper');
@@ -9,6 +10,7 @@ module.exports = redefine.Class({
   constructor: function(path, options) {
     this.path    = _path.resolve(path);
     this.file    = _path.basename(this.path);
+    this.name    = _path.basename(this.file, _path.extname(this.file));
     this.options = options;
    },
 
@@ -29,6 +31,25 @@ module.exports = redefine.Class({
     return require(this.path);
   },
 
+  migrations: function () {
+    var migration  = this.migration();
+    var migrations = migration.migrations;
+
+    if (typeof migrations === 'function') {
+      migrations = migrations();
+    }
+
+    if (typeof migrations === 'string') {
+      migrations = [ migrations ];
+    }
+
+    if (Array.isArray(migrations)) {
+      return migrations;
+    } else {
+      return [ this.file ];
+    }
+  },
+
   up: function () {
     return this._exec('up', [].slice.apply(arguments));
   },
@@ -38,7 +59,13 @@ module.exports = redefine.Class({
   },
 
   testFileName: function (needle) {
-    return this.file.indexOf(needle) === 0;
+    if (!Array.isArray(needle)) {
+      return this.testFileName([ needle ]);
+    }
+
+    return _.any(needle, function (fileName) {
+      return this.file.indexOf(fileName) === 0;
+    }, this);
   },
 
   _exec: function (method, args) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -40,8 +40,6 @@ var helper = module.exports = {
       var names = options.names;
       var num   = 0;
 
-      helper.clearTmp();
-
       _.times(count, function (i) {
         num++;
         names.push(options.names[i] || (num + '-migration'));
@@ -50,6 +48,23 @@ var helper = module.exports = {
 
       resolve(names);
     });
+  },
+
+  prepare: function (options) {
+    options = options || {};
+
+    options.migrations = _.assign({
+      count: 0
+    }, options.migrations || {});
+
+    helper.clearTmp();
+
+    return Bluebird.join(
+      helper.prepareMigrations(
+        options.migrations.count,
+        options.migrations.options
+      )
+    );
   },
 
   wrapStorageAsCustomThenable: function(storage) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -15,12 +15,14 @@ var helper = module.exports = {
     });
 
     // empty tmp/squashes directory
-    var squashes = fs.readdirSync(__dirname + '/tmp/squashes');
-    squashes.forEach(function (file) {
-      if (file.match(/\.(js|json|sqlite)$/)) {
-        fs.unlinkSync(__dirname + '/tmp/squashes/' + file);
-      }
-    });
+    if (fs.existsSync(__dirname + '/tmp/squashes')) {
+      var squashes = fs.readdirSync(__dirname + '/tmp/squashes');
+      squashes.forEach(function (file) {
+        if (file.match(/\.(js|json|sqlite)$/)) {
+          fs.unlinkSync(__dirname + '/tmp/squashes/' + file);
+        }
+      });
+    }
 
     // forget all required files under tmp directory
     for (var path in require.cache) {
@@ -49,6 +51,10 @@ var helper = module.exports = {
   },
 
   generateDummySquash: function (name, migrations) {
+    if (!fs.existsSync(__dirname + '/tmp/squashes')) {
+      fs.mkdirSync(__dirname + '/tmp/squashes');
+    }
+
     fs.writeFileSync(
       __dirname + '/tmp/squashes/' + name + '.js',
       [

--- a/test/index/down.test.js
+++ b/test/index/down.test.js
@@ -9,9 +9,11 @@ describe('Umzug', function () {
   describe('down', function () {
     beforeEach(function () {
       return helper
-        .prepareMigrations(3)
+        .prepare({
+          migrations: { count: 3 }
+        })
         .bind(this)
-        .then(function (migrationNames) {
+        .spread(function (migrationNames) {
           this.migrationNames = migrationNames;
           this.umzug          = new Umzug({
             migrations:     { path: __dirname + '/../tmp/' },

--- a/test/index/down.test.js
+++ b/test/index/down.test.js
@@ -7,123 +7,182 @@ var Umzug     = require('../../index');
 
 describe('Umzug', function () {
   describe('down', function () {
-    beforeEach(function () {
-      return helper
-        .prepare({
-          migrations: { count: 3 }
-        })
-        .bind(this)
-        .spread(function (migrationNames) {
-          this.migrationNames = migrationNames;
-          this.umzug          = new Umzug({
-            migrations:     { path: __dirname + '/../tmp/' },
-            storageOptions: { path: __dirname + '/../tmp/umzug.json' }
+    describe('without squashes', function () {
+      beforeEach(function () {
+        return helper
+          .prepare({
+            migrations: { count: 3 }
+          })
+          .bind(this)
+          .spread(function (migrationNames) {
+            this.migrationNames = migrationNames;
+            this.umzug = new Umzug({
+              migrations:     { path: __dirname + '/../tmp/' },
+              storageOptions: { path: __dirname + '/../tmp/umzug.json' }
+            });
           });
-        });
-    });
-
-    describe('when no migrations has been executed yet', function () {
-      beforeEach(function () {
-        return this.umzug.down().bind(this).then(function (migrations) {
-          this.migrations = migrations;
-        });
       });
 
-      it('returns an array', function () {
-        expect(this.migrations).to.be.an(Array);
-      });
-
-      it('returns 0 items', function () {
-        expect(this.migrations).to.have.length(0);
-      });
-    });
-
-    describe('when a migration has been executed already', function () {
-      beforeEach(function () {
-        return this.umzug.execute({
-          migrations: [ this.migrationNames[0] ],
-          method:     'up'
-        }).bind(this).then(function () {
-          return this.umzug.executed();
-        }).then(function (migrations) {
-          expect(migrations).to.have.length(1);
-        }).then(function () {
-          return this.umzug.down();
-        }).then(function (migrations) {
-          this.migrations = migrations;
-        });
-      });
-
-      it('returns 1 item', function () {
-        expect(this.migrations).to.have.length(1);
-        expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
-      });
-
-      it('removes the reverted migrations from the storage', function () {
-        return this.umzug.executed().then(function (migrations) {
-          expect(migrations).to.have.length(0);
-        });
-      });
-    });
-
-    describe('when all migrations have been executed already', function () {
-      beforeEach(function () {
-        return this.umzug.execute({
-          migrations: this.migrationNames,
-          method:     'up'
-        }).bind(this).then(function () {
-          return this.umzug.executed();
-        }).then(function (migrations) {
-          expect(migrations).to.have.length(3);
-        });
-      });
-
-      describe('when no option is specified', function () {
+      describe('when no migrations has been executed yet', function () {
         beforeEach(function () {
           return this.umzug.down().bind(this).then(function (migrations) {
             this.migrations = migrations;
           });
         });
 
-        it('returns 1 item', function () {
-          expect(this.migrations).to.have.length(1);
-          expect(this.migrations[0].file).to.equal(this.migrationNames[2] + '.js');
+        it('returns an array', function () {
+          expect(this.migrations).to.be.an(Array);
         });
 
-        it('removes the reverted migrations from the storage', function () {
-          return this.umzug.executed().bind(this).then(function (migrations) {
-            expect(migrations).to.have.length(2);
-            expect(migrations[0].file).to.equal(this.migrationNames[0] + '.js');
-            expect(migrations[1].file).to.equal(this.migrationNames[1] + '.js');
-          });
+        it('returns 0 items', function () {
+          expect(this.migrations).to.have.length(0);
         });
       });
 
-      describe('when `to` option is passed', function () {
+      describe('when a migration has been executed already', function () {
         beforeEach(function () {
-          return this.umzug.down({
-            to: this.migrationNames[1]
-          }).bind(this).then(function (migrations) {
+          return this.umzug.execute({
+            migrations: [this.migrationNames[0]],
+            method: 'up'
+          }).bind(this).then(function () {
+            return this.umzug.executed();
+          }).then(function (migrations) {
+            expect(migrations).to.have.length(1);
+          }).then(function () {
+            return this.umzug.down();
+          }).then(function (migrations) {
             this.migrations = migrations;
           });
         });
 
-        it('returns 2 item', function () {
-          expect(this.migrations).to.have.length(2);
-          expect(this.migrations[0].file).to.equal(this.migrationNames[2] + '.js');
-          expect(this.migrations[1].file).to.equal(this.migrationNames[1] + '.js');
+        it('returns 1 migration', function () {
+          expect(this.migrations).to.have.length(1);
+          expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
         });
 
         it('removes the reverted migrations from the storage', function () {
-          return this.umzug.executed().bind(this).then(function (migrations) {
-            expect(migrations).to.have.length(1);
-            expect(migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+          return this.umzug.executed().then(function (migrations) {
+            expect(migrations).to.have.length(0);
+          });
+        });
+      });
+
+      describe('when all migrations have been executed already', function () {
+        beforeEach(function () {
+          return this.umzug.execute({
+            migrations: this.migrationNames,
+            method: 'up'
+          }).bind(this).then(function () {
+            return this.umzug.executed();
+          }).then(function (migrations) {
+            expect(migrations).to.have.length(3);
+          });
+        });
+
+        describe('when no option is specified', function () {
+          beforeEach(function () {
+            return this.umzug.down().bind(this).then(function (migrations) {
+              this.migrations = migrations;
+            });
+          });
+
+          it('returns 1 migration', function () {
+            expect(this.migrations).to.have.length(1);
+            expect(this.migrations[0].file).to.equal(this.migrationNames[2] + '.js');
+          });
+
+          it('removes the reverted migrations from the storage', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(2);
+              expect(migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+              expect(migrations[1].file).to.equal(this.migrationNames[1] + '.js');
+            });
+          });
+        });
+
+        describe('when `to` option is passed', function () {
+          beforeEach(function () {
+            return this.umzug.down({
+              to: this.migrationNames[1]
+            }).bind(this).then(function (migrations) {
+              this.migrations = migrations;
+            });
+          });
+
+          it('returns 2 migrations', function () {
+            expect(this.migrations).to.have.length(2);
+            expect(this.migrations[0].file).to.equal(this.migrationNames[2] + '.js');
+            expect(this.migrations[1].file).to.equal(this.migrationNames[1] + '.js');
+          });
+
+          it('removes the reverted migrations from the storage', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(1);
+              expect(migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+            });
+          });
+
+          describe('that does not match a migration', function () {
+            it('rejects the promise', function () {
+              return this.umzug.down({to: '123-asdasd'}).then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+              });
+            });
+          });
+
+          describe('that does not match an executed migration', function () {
+            it('rejects the promise', function () {
+              return this.umzug
+                .execute({migrations: this.migrationNames, method: 'down'})
+                .bind(this)
+                .then(function () {
+                  return this.umzug.down({to: this.migrationNames[1]});
+                })
+                .then(function () {
+                  return Bluebird.reject('We should not end up here...');
+                }, function (err) {
+                  expect(err.message).to.equal('Migration was not executed: 2-migration.js');
+                });
+            });
+          });
+        });
+      });
+
+      describe('when called with a string', function () {
+        beforeEach(function () {
+          return this.umzug.execute({
+            migrations: this.migrationNames,
+            method: 'up'
+          });
+        });
+
+        describe('that matches an executed migration', function () {
+          beforeEach(function () {
+            return this.umzug.down(this.migrationNames[1]).bind(this)
+              .then(function (migrations) {
+                this.migrations = migrations;
+              });
+          });
+
+          it('returns only 1 migration', function () {
+            expect(this.migrations).to.have.length(1);
+            expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+          });
+
+          it('reverts only the second migrations', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(2);
+              expect(migrations[0].testFileName(this.migrationNames[0])).to.be.ok();
+              expect(migrations[1].testFileName(this.migrationNames[2])).to.be.ok();
+            });
           });
         });
 
         describe('that does not match a migration', function () {
           it('rejects the promise', function () {
-            return this.umzug.down({ to: '123-asdasd' }).then(function () {
+            return this.umzug.down('123-asdasd').then(function () {
               return Bluebird.reject('We should not end up here...');
             }, function (err) {
               expect(err.message).to.equal('Unable to find migration: 123-asdasd');
@@ -134,10 +193,10 @@ describe('Umzug', function () {
         describe('that does not match an executed migration', function () {
           it('rejects the promise', function () {
             return this.umzug
-              .execute({ migrations: this.migrationNames, method: 'down' })
+              .execute({migrations: this.migrationNames, method: 'down'})
               .bind(this)
               .then(function () {
-                return this.umzug.down({ to: this.migrationNames[1] });
+                return this.umzug.down(this.migrationNames[1]);
               })
               .then(function () {
                 return Bluebird.reject('We should not end up here...');
@@ -147,185 +206,476 @@ describe('Umzug', function () {
           });
         });
       });
-    });
 
-    describe('when called with a string', function () {
-      beforeEach(function () {
-        return this.umzug.execute({
-          migrations: this.migrationNames,
-          method:     'up'
-        });
-      });
-
-      describe('that matches an executed migration', function () {
+      describe('when called with an array', function () {
         beforeEach(function () {
-          return this.umzug.down(this.migrationNames[1]).bind(this)
-            .then(function (migrations) { this.migrations = migrations; });
-        });
-
-        it('returns only 1 migrations', function () {
-          expect(this.migrations).to.have.length(1);
-        });
-
-        it('reverts only the second migrations', function () {
-          return this.umzug.executed().bind(this).then(function (migrations) {
-            expect(migrations).to.have.length(2);
-            expect(migrations[0].testFileName(this.migrationNames[0])).to.be.ok();
-            expect(migrations[1].testFileName(this.migrationNames[2])).to.be.ok();
+          return this.umzug.execute({
+            migrations: this.migrationNames,
+            method: 'up'
           });
         });
-      });
 
-      describe('that does not match a migration', function () {
-        it('rejects the promise', function () {
-          return this.umzug.down('123-asdasd').then(function () {
-            return Bluebird.reject('We should not end up here...');
-          }, function (err) {
-            expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+        describe('that matches an executed migration', function () {
+          beforeEach(function () {
+            return this.umzug.down([this.migrationNames[1]]).bind(this)
+              .then(function (migrations) {
+                this.migrations = migrations;
+              });
+          });
+
+          it('returns only 1 migration', function () {
+            expect(this.migrations).to.have.length(1);
+            expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+          });
+
+          it('reverts only the second migrations', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(2);
+              expect(migrations[0].testFileName(this.migrationNames[0])).to.be.ok();
+              expect(migrations[1].testFileName(this.migrationNames[2])).to.be.ok();
+            });
           });
         });
-      });
 
-      describe('that does not match an executed migration', function () {
-        it('rejects the promise', function () {
-          return this.umzug
-            .execute({ migrations: this.migrationNames, method: 'down' })
-            .bind(this)
-            .then(function () {
-              return this.umzug.down(this.migrationNames[1]);
-            })
-            .then(function () {
+        describe('that matches multiple pending migration', function () {
+          beforeEach(function () {
+            return this.umzug.down(this.migrationNames.slice(1)).bind(this)
+              .then(function (migrations) {
+                this.migrations = migrations;
+              });
+          });
+
+          it('returns only 2 migrations', function () {
+            expect(this.migrations).to.have.length(2);
+            expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+            expect(this.migrations[1].file).to.equal(this.migrationNames[2] + '.js');
+          });
+
+          it('reverts only the second and the third migrations', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(1);
+              expect(migrations[0].testFileName(this.migrationNames[0])).to.be.ok();
+            });
+          });
+        });
+
+        describe('that does not match a migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug.down(['123-asdasd']).then(function () {
               return Bluebird.reject('We should not end up here...');
             }, function (err) {
-              expect(err.message).to.equal('Migration was not executed: 2-migration.js');
+              expect(err.message).to.equal('Unable to find migration: 123-asdasd');
             });
-        });
-      });
-    });
-
-    describe('when called with an array', function () {
-      beforeEach(function () {
-        return this.umzug.execute({
-          migrations: this.migrationNames,
-          method:     'up'
-        });
-      });
-
-      describe('that matches an executed migration', function () {
-        beforeEach(function () {
-          return this.umzug.down([this.migrationNames[1]]).bind(this)
-            .then(function (migrations) { this.migrations = migrations; });
+          });
         });
 
-        it('returns only 1 migrations', function () {
-          expect(this.migrations).to.have.length(1);
+        describe('that does not match an executed migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({migrations: this.migrationNames, method: 'down'})
+              .bind(this)
+              .then(function () {
+                return this.umzug.down([this.migrationNames[1]]);
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration was not executed: 2-migration.js');
+              });
+          });
         });
 
-        it('reverts only the second migrations', function () {
-          return this.umzug.executed().bind(this).then(function (migrations) {
-            expect(migrations).to.have.length(2);
-            expect(migrations[0].testFileName(this.migrationNames[0])).to.be.ok();
-            expect(migrations[1].testFileName(this.migrationNames[2])).to.be.ok();
+        describe('that does partially not match an executed migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({
+                migrations: this.migrationNames.slice(0, 2),
+                method: 'down'
+              })
+              .bind(this)
+              .then(function () {
+                return this.umzug.down(this.migrationNames.slice(1));
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration was not executed: 2-migration.js');
+              });
           });
         });
       });
 
-      describe('that matches multiple pending migration', function () {
+      describe('when storage returns a thenable', function () {
         beforeEach(function () {
-          return this.umzug.down(this.migrationNames.slice(1)).bind(this)
-            .then(function (migrations) { this.migrations = migrations; });
-        });
-
-        it('returns only 2 migrations', function () {
-          expect(this.migrations).to.have.length(2);
-        });
-
-        it('reverts only the second and the third migrations', function () {
-          return this.umzug.executed().bind(this).then(function (migrations) {
+          //a migration has been executed already...
+          return this.umzug.execute({
+            migrations: [this.migrationNames[0]],
+            method: 'up'
+          }).bind(this).then(function () {
+            return this.umzug.executed();
+          }).then(function (migrations) {
             expect(migrations).to.have.length(1);
-            expect(migrations[0].testFileName(this.migrationNames[0])).to.be.ok();
+          }).then(function () {
+
+            //storage returns a thenable
+            this.umzug.storage = helper.wrapStorageAsCustomThenable(this.umzug.storage);
+
+            return this.umzug.down();
+          }).then(function (migrations) {
+            this.migrations = migrations;
           });
-        });
-      });
 
-      describe('that does not match a migration', function () {
-        it('rejects the promise', function () {
-          return this.umzug.down(['123-asdasd']).then(function () {
-            return Bluebird.reject('We should not end up here...');
-          }, function (err) {
-            expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+        });
+
+        it('returns 1 migration', function () {
+          expect(this.migrations).to.have.length(1);
+          expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+        });
+
+        it('removes the reverted migrations from the storage', function () {
+          return this.umzug.executed().then(function (migrations) {
+            expect(migrations).to.have.length(0);
           });
-        });
-      });
-
-      describe('that does not match an executed migration', function () {
-        it('rejects the promise', function () {
-          return this.umzug
-            .execute({ migrations: this.migrationNames, method: 'down' })
-            .bind(this)
-            .then(function () {
-              return this.umzug.down([this.migrationNames[1]]);
-            })
-            .then(function () {
-              return Bluebird.reject('We should not end up here...');
-            }, function (err) {
-              expect(err.message).to.equal('Migration was not executed: 2-migration.js');
-            });
-        });
-      });
-
-      describe('that does partially not match an executed migration', function () {
-        it('rejects the promise', function () {
-          return this.umzug
-            .execute({ migrations: this.migrationNames.slice(0, 2), method: 'down' })
-            .bind(this)
-            .then(function () {
-              return this.umzug.down(this.migrationNames.slice(1));
-            })
-            .then(function () {
-              return Bluebird.reject('We should not end up here...');
-            }, function (err) {
-              expect(err.message).to.equal('Migration was not executed: 2-migration.js');
-            });
         });
       });
     });
 
-    describe('when storage returns a thenable', function() {
+    describe('with squashes', function () {
+      beforeEach(function () {
+        return helper
+          .prepare({
+            migrations: { count: 3 },
+            squashes:   { count: 3, options: {
+              migrations: [
+                [ '1-migration.js', '2-migration.js' ],
+                [ '2-migration.js', '3-migration.js' ],
+                [ '1-migration.js', '2-migration.js', '3-migration.js' ]
+              ]
+            }}
+          })
+          .bind(this)
+          .spread(function (migrationNames, squashNames) {
+            this.migrationNames = migrationNames;
+            this.squashNames = squashNames;
+            this.umzug = new Umzug({
+              migrations:     { path: __dirname + '/../tmp/' },
+              squashes:       { path: __dirname + '/../tmp/squashes/' },
+              storageOptions: { path: __dirname + '/../tmp/umzug.json' }
+            });
+          });
+      });
 
-      beforeEach(function() {
-
-        //a migration has been executed already...
-        return this.umzug.execute({
-          migrations: [ this.migrationNames[0] ],
-          method:     'up'
-        }).bind(this).then(function () {
-          return this.umzug.executed();
-        }).then(function (migrations) {
-          expect(migrations).to.have.length(1);
-        }).then(function () {
-
-          //storage returns a thenable
-          this.umzug.storage = helper.wrapStorageAsCustomThenable(this.umzug.storage);
-
-          return this.umzug.down();
-        }).then(function (migrations) {
-          this.migrations = migrations;
+      describe('when no migrations has been executed yet', function () {
+        beforeEach(function () {
+          return this.umzug.down().bind(this).then(function (migrations) {
+            this.migrations = migrations;
+          });
         });
 
-      });
+        it('returns an array', function () {
+          expect(this.migrations).to.be.an(Array);
+        });
 
-      it('returns 1 item', function () {
-        expect(this.migrations).to.have.length(1);
-        expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
-      });
-
-      it('removes the reverted migrations from the storage', function () {
-        return this.umzug.executed().then(function (migrations) {
-          expect(migrations).to.have.length(0);
+        it('returns 0 items', function () {
+          expect(this.migrations).to.have.length(0);
         });
       });
 
+      describe('when a migration has been executed already', function () {
+        beforeEach(function () {
+          return this.umzug.execute({
+            migrations: [this.migrationNames[0]],
+            method: 'up'
+          }).bind(this).then(function () {
+            return this.umzug.executed();
+          }).then(function (migrations) {
+            expect(migrations).to.have.length(1);
+          }).then(function () {
+            return this.umzug.down();
+          }).then(function (migrations) {
+            this.migrations = migrations;
+          });
+        });
+
+        it('returns 1 migration', function () {
+          expect(this.migrations).to.have.length(1);
+          expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+        });
+
+        it('removes the reverted migrations from the storage', function () {
+          return this.umzug.executed().then(function (migrations) {
+            expect(migrations).to.have.length(0);
+          });
+        });
+      });
+
+      describe('when all migrations have been executed already', function () {
+        beforeEach(function () {
+          return this.umzug.execute({
+            migrations: this.migrationNames,
+            method: 'up'
+          }).bind(this).then(function () {
+            return this.umzug.executed();
+          }).then(function (migrations) {
+            expect(migrations).to.have.length(3);
+          });
+        });
+
+        describe('when no option is specified', function () {
+          beforeEach(function () {
+            return this.umzug.down().bind(this).then(function (migrations) {
+              this.migrations = migrations;
+            });
+          });
+
+          it('returns 1 migration', function () {
+            expect(this.migrations).to.have.length(1);
+            expect(this.migrations[0].file).to.equal(this.migrationNames[2] + '.js');
+          });
+
+          it('removes the reverted migrations from the storage', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(2);
+              expect(migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+              expect(migrations[1].file).to.equal(this.migrationNames[1] + '.js');
+            });
+          });
+        });
+
+        describe('when `to` option is passed', function () {
+          beforeEach(function () {
+            return this.umzug.down({
+              to: this.migrationNames[1]
+            }).bind(this).then(function (migrations) {
+              this.migrations = migrations;
+            });
+          });
+
+          it('returns 1 squash', function () {
+            expect(this.migrations).to.have.length(1);
+            expect(this.migrations[0].file).to.equal(this.squashNames[1] + '.js');
+          });
+
+          it('removes the reverted migrations from the storage', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(1);
+              expect(migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+            });
+          });
+
+          describe('that does not match a migration', function () {
+            it('rejects the promise', function () {
+              return this.umzug.down({to: '123-asdasd'}).then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+              });
+            });
+          });
+
+          describe('that does not match an executed migration', function () {
+            it('rejects the promise', function () {
+              return this.umzug
+                .execute({migrations: this.migrationNames, method: 'down'})
+                .bind(this)
+                .then(function () {
+                  return this.umzug.down({to: this.migrationNames[1]});
+                })
+                .then(function () {
+                  return Bluebird.reject('We should not end up here...');
+                }, function (err) {
+                  expect(err.message).to.equal('Migration was not executed: 2-migration.js');
+                });
+            });
+          });
+        });
+      });
+
+      describe('when called with a string', function () {
+        beforeEach(function () {
+          return this.umzug.execute({
+            migrations: this.migrationNames,
+            method: 'up'
+          });
+        });
+
+        describe('that matches an executed migration', function () {
+          beforeEach(function () {
+            return this.umzug.down(this.migrationNames[1]).bind(this)
+              .then(function (migrations) {
+                this.migrations = migrations;
+              });
+          });
+
+          it('returns only 1 migrations', function () {
+            expect(this.migrations).to.have.length(1);
+          });
+
+          it('reverts only the second migrations', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(2);
+              expect(migrations[0].testFileName(this.migrationNames[0])).to.be.ok();
+              expect(migrations[1].testFileName(this.migrationNames[2])).to.be.ok();
+            });
+          });
+        });
+
+        describe('that does not match a migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug.down('123-asdasd').then(function () {
+              return Bluebird.reject('We should not end up here...');
+            }, function (err) {
+              expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+            });
+          });
+        });
+
+        describe('that does not match an executed migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({migrations: this.migrationNames, method: 'down'})
+              .bind(this)
+              .then(function () {
+                return this.umzug.down(this.migrationNames[1]);
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration was not executed: 2-migration.js');
+              });
+          });
+        });
+      });
+
+      describe('when called with an array', function () {
+        beforeEach(function () {
+          return this.umzug.execute({
+            migrations: this.migrationNames,
+            method: 'up'
+          });
+        });
+
+        describe('that matches an executed migration', function () {
+          beforeEach(function () {
+            return this.umzug.down([this.migrationNames[1]]).bind(this)
+              .then(function (migrations) {
+                this.migrations = migrations;
+              });
+          });
+
+          it('returns only 1 migrations', function () {
+            expect(this.migrations).to.have.length(1);
+            expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+          });
+
+          it('reverts only the second migrations', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(2);
+              expect(migrations[0].testFileName(this.migrationNames[0])).to.be.ok();
+              expect(migrations[1].testFileName(this.migrationNames[2])).to.be.ok();
+            });
+          });
+        });
+
+        describe('that matches multiple pending migration', function () {
+          beforeEach(function () {
+            return this.umzug.down(this.migrationNames.slice(1)).bind(this)
+              .then(function (migrations) {
+                this.migrations = migrations;
+              });
+          });
+
+          it('returns only 1 squash', function () {
+            expect(this.migrations).to.have.length(1);
+            expect(this.migrations[0].file).to.equal(this.squashNames[1] + '.js');
+          });
+
+          it('reverts only the second and the third migrations', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(1);
+              expect(migrations[0].testFileName(this.migrationNames[0])).to.be.ok();
+            });
+          });
+        });
+
+        describe('that does not match a migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug.down(['123-asdasd']).then(function () {
+              return Bluebird.reject('We should not end up here...');
+            }, function (err) {
+              expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+            });
+          });
+        });
+
+        describe('that does not match an executed migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({migrations: this.migrationNames, method: 'down'})
+              .bind(this)
+              .then(function () {
+                return this.umzug.down([this.migrationNames[1]]);
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration was not executed: 2-migration.js');
+              });
+          });
+        });
+
+        describe('that does partially not match an executed migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({
+                migrations: this.migrationNames.slice(0, 2),
+                method: 'down'
+              })
+              .bind(this)
+              .then(function () {
+                return this.umzug.down(this.migrationNames.slice(1));
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration was not executed: 2-migration.js');
+              });
+          });
+        });
+      });
+
+      describe('when storage returns a thenable', function () {
+        beforeEach(function () {
+          //a migration has been executed already...
+          return this.umzug.execute({
+            migrations: [this.migrationNames[0]],
+            method: 'up'
+          }).bind(this).then(function () {
+            return this.umzug.executed();
+          }).then(function (migrations) {
+            expect(migrations).to.have.length(1);
+          }).then(function () {
+
+            //storage returns a thenable
+            this.umzug.storage = helper.wrapStorageAsCustomThenable(this.umzug.storage);
+
+            return this.umzug.down();
+          }).then(function (migrations) {
+            this.migrations = migrations;
+          });
+        });
+
+        it('returns 1 migration', function () {
+          expect(this.migrations).to.have.length(1);
+          expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+        });
+
+        it('removes the reverted migrations from the storage', function () {
+          return this.umzug.executed().then(function (migrations) {
+            expect(migrations).to.have.length(0);
+          });
+        });
+      });
     });
   });
 });

--- a/test/index/execute.test.js
+++ b/test/index/execute.test.js
@@ -10,7 +10,9 @@ describe('Umzug', function () {
   describe('execute', function () {
     beforeEach(function () {
       return helper
-        .prepareMigrations(1, { names: ['123-migration'] })
+        .prepare({
+          migrations: { count: 1, options: { names: ['123-migration'] } }
+        })
         .bind(this)
         .then(function () {
           this.migration = require('../tmp/123-migration.js');

--- a/test/index/execute.test.js
+++ b/test/index/execute.test.js
@@ -8,99 +8,180 @@ var sinon     = require('sinon');
 
 describe('Umzug', function () {
   describe('execute', function () {
-    beforeEach(function () {
-      return helper
-        .prepare({
-          migrations: { count: 1, options: { names: ['123-migration'] } }
-        })
-        .bind(this)
-        .then(function () {
-          this.migration = require('../tmp/123-migration.js');
-          this.upStub    = sinon.stub(this.migration, 'up', Bluebird.resolve);
-          this.downStub  = sinon.stub(this.migration, 'down', Bluebird.resolve);
-          this.logSpy    = sinon.spy();
-          this.umzug     = new Umzug({
-            migrations:     { path: __dirname + '/../tmp/' },
-            storageOptions: { path: __dirname + '/../tmp/umzug.json' },
-            logging:        this.logSpy
-          });
-          this.migrate = function (method) {
-            return this.umzug.execute({
-              migrations: ['123-migration'],
-              method:     method
+    describe('without squashes', function () {
+      beforeEach(function () {
+        return helper
+          .prepare({
+            migrations: { count: 1, options: { names: ['123-migration'] } }
+          })
+          .bind(this)
+          .then(function () {
+            this.migration = require('../tmp/123-migration.js');
+            this.upStub    = sinon.stub(this.migration, 'up', Bluebird.resolve);
+            this.downStub  = sinon.stub(this.migration, 'down', Bluebird.resolve);
+            this.logSpy    = sinon.spy();
+            this.umzug     = new Umzug({
+              migrations:     { path: __dirname + '/../tmp/' },
+              storageOptions: { path: __dirname + '/../tmp/umzug.json' },
+              logging:        this.logSpy
             });
-          }.bind(this);
-        });
-    });
+            this.migrate = function (method) {
+              return this.umzug.execute({
+                migrations: ['123-migration'],
+                method:     method
+              });
+            }.bind(this);
+          });
+      });
 
-    afterEach(function () {
-      this.migration.up.restore();
-      this.migration.down.restore();
-    });
+      afterEach(function () {
+        this.migration.up.restore();
+        this.migration.down.restore();
+      });
 
-    it('runs the up method of the migration', function () {
-      return this
-        .migrate('up').bind(this)
-        .then(function () {
+      it('runs the up method of the migration', function () {
+        return this
+          .migrate('up').bind(this)
+          .then(function () {
+            expect(this.upStub.callCount).to.equal(1);
+            expect(this.downStub.callCount).to.equal(0);
+            expect(this.logSpy.callCount).to.equal(2);
+            expect(this.logSpy.getCall(0).args[0]).to.equal('== 123-migration: migrating =======');
+            expect(this.logSpy.getCall(1).args[0]).to.match(/== 123-migration: migrated \(0\.0\d\ds\)/);
+          });
+      });
+
+      it('runs the down method of the migration', function () {
+        return this
+          .migrate('down').bind(this)
+          .then(function () {
+            expect(this.upStub.callCount).to.equal(0);
+            expect(this.downStub.callCount).to.equal(1);
+            expect(this.logSpy.callCount).to.equal(2);
+            expect(this.logSpy.getCall(0).args[0]).to.equal('== 123-migration: reverting =======');
+            expect(this.logSpy.getCall(1).args[0]).to.match(/== 123-migration: reverted \(0\.0\d\ds\)/);
+          });
+      });
+
+      it('does not execute a migration twice', function () {
+        return this.migrate('up').bind(this).then(function () {
+          return this.migrate('up');
+        }).then(function () {
           expect(this.upStub.callCount).to.equal(1);
           expect(this.downStub.callCount).to.equal(0);
-          expect(this.logSpy.callCount).to.equal(2);
-          expect(this.logSpy.getCall(0).args[0]).to.equal('== 123-migration: migrating =======');
-          expect(this.logSpy.getCall(1).args[0]).to.match(/== 123-migration: migrated \(0\.0\d\ds\)/);
         });
-    });
+      });
 
-    it('runs the down method of the migration', function () {
-      return this
-        .migrate('down').bind(this)
-        .then(function () {
-          expect(this.upStub.callCount).to.equal(0);
-          expect(this.downStub.callCount).to.equal(1);
-          expect(this.logSpy.callCount).to.equal(2);
-          expect(this.logSpy.getCall(0).args[0]).to.equal('== 123-migration: reverting =======');
-          expect(this.logSpy.getCall(1).args[0]).to.match(/== 123-migration: reverted \(0\.0\d\ds\)/);
+      it('does not add an executed entry to the storage.json', function () {
+        return this.migrate('up').bind(this).then(function () {
+          return this.migrate('up');
+        }).then(function () {
+          var storage = require(this.umzug.options.storageOptions.path);
+          expect(storage).to.eql(['123-migration.js']);
         });
-    });
+      });
 
-    it('does not execute a migration twice', function () {
-      return this.migrate('up').bind(this).then(function () {
-        return this.migrate('up');
-      }).then(function () {
-        expect(this.upStub.callCount).to.equal(1);
-        expect(this.downStub.callCount).to.equal(0);
+      it('calls the migration without params by default', function () {
+        return this.migrate('up').bind(this).then(function () {
+          expect(this.upStub.getCall(0).args).to.eql([]);
+        });
+      });
+
+      it('calls the migration with the specified params', function () {
+        this.umzug.options.migrations.params = [1, 2, 3];
+
+        return this.migrate('up').bind(this).then(function () {
+          expect(this.upStub.getCall(0).args).to.eql([1, 2, 3]);
+        });
+      });
+
+      it('calls the migration with the result of the passed function', function () {
+        this.umzug.options.migrations.params = function () {
+          return [1, 2, 3];
+        };
+
+        return this.migrate('up').bind(this).then(function () {
+          expect(this.upStub.getCall(0).args).to.eql([1, 2, 3]);
+        });
       });
     });
 
-    it('does not add an executed entry to the storage.json', function () {
-      return this.migrate('up').bind(this).then(function () {
-        return this.migrate('up');
-      }).then(function () {
-        var storage = require(this.umzug.options.storageOptions.path);
-        expect(storage).to.eql(['123-migration.js']);
+    describe('with squashes', function () {
+      beforeEach(function () {
+        return helper
+          .prepare({
+            migrations: { count: 7},
+            squashes:   { count: 4, options: {
+              migrations: [
+                [ '1-migration.js', '2-migration.js', '3-migration.js' ],
+                [ '3-migration.js', '4-migration.js' ],
+                [
+                  '1-migration.js', '2-migration.js', '3-migration.js',
+                  '4-migration.js', '5-migration.js', '6-migration.js',
+                  '7-migration.js'
+                ],
+                [ '5-migration.js', '6-migration.js' ]
+              ]
+            }}
+          })
+          .bind(this)
+          .spread(function (migrationNames, squashNames) {
+            this.migrationNames = migrationNames;
+            this.squashNames = squashNames;
+            this.umzug = new Umzug({
+              migrations:     { path: __dirname + '/../tmp/' },
+              squashes:       { path: __dirname + '/../tmp/squashes/' },
+              storageOptions: { path: __dirname + '/../tmp/umzug.json' }
+            });
+          });
       });
-    });
-
-    it('calls the migration without params by default', function () {
-      return this.migrate('up').bind(this).then(function () {
-        expect(this.upStub.getCall(0).args).to.eql([]);
+      it('chooses fully matching squash', function () {
+        return this.umzug.execute({
+          migrations: this.migrationNames,
+          method: 'up'
+        }).bind(this)
+          .then(function (migrations) {
+            expect(migrations).to.have.length(1);
+            expect(migrations[0].file).to.equal(this.squashNames[2] + '.js');
+          });
       });
-    });
 
-    it('calls the migration with the specified params', function () {
-      this.umzug.options.migrations.params = [1, 2, 3];
-
-      return this.migrate('up').bind(this).then(function () {
-        expect(this.upStub.getCall(0).args).to.eql([1, 2, 3]);
+      it('chooses squashes and migrations in the correct order', function () {
+        return this.umzug.execute({
+          migrations: this.migrationNames.slice(0, 6),
+          method: 'up'
+        }).bind(this)
+          .then(function (migrations) {
+            expect(migrations).to.have.length(3);
+            expect(migrations[0].file).to.equal(this.squashNames[0] + '.js');
+            expect(migrations[1].file).to.equal(this.migrationNames[3] + '.js');
+            expect(migrations[2].file).to.equal(this.squashNames[3] + '.js');
+          });
       });
-    });
 
-    it('calls the migration with the result of the passed function', function () {
-      this.umzug.options.migrations.params = function () {
-        return [1, 2, 3];
-      };
+      it('does not choose overlapping squashes', function () {
+        return this.umzug.execute({
+          migrations: this.migrationNames.slice(0, 5),
+          method: 'up'
+        }).bind(this)
+          .then(function (migrations) {
+            expect(migrations).to.have.length(3);
+            expect(migrations[0].file).to.equal(this.squashNames[0] + '.js');
+            expect(migrations[1].file).to.equal(this.migrationNames[3] + '.js');
+            expect(migrations[2].file).to.equal(this.migrationNames[4] + '.js');
+          });
+      });
 
-      return this.migrate('up').bind(this).then(function () {
-        expect(this.upStub.getCall(0).args).to.eql([1, 2, 3]);
+      it('does not choose partially matching squash', function () {
+        return this.umzug.execute({
+          migrations: this.migrationNames.slice(0, 2),
+          method: 'up'
+        }).bind(this)
+          .then(function (migrations) {
+            expect(migrations).to.have.length(2);
+            expect(migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+            expect(migrations[1].file).to.equal(this.migrationNames[1] + '.js');
+          });
       });
     });
   });

--- a/test/index/executed.test.js
+++ b/test/index/executed.test.js
@@ -9,13 +9,22 @@ describe('Umzug', function () {
     beforeEach(function () {
       return helper
         .prepare({
-          migrations: { count: 3 }
+          migrations: { count: 3 },
+          squashes:   { count: 3, options: {
+            migrations: [
+              [ '1-migration.js', '2-migration.js' ],
+              [ '2-migration.js', '3-migration.js' ],
+              [ '1-migration.js', '2-migration.js', '3-migration.js' ]
+            ]
+          }}
         })
         .bind(this)
-        .spread(function (migrationNames) {
+        .spread(function (migrationNames, squashNames) {
           this.migrationNames = migrationNames;
+          this.squashNames = squashNames;
           this.umzug          = new Umzug({
             migrations:     { path: __dirname + '/../tmp/' },
+            squashes:       { path: __dirname + '/../tmp/squashes/' },
             storageOptions: { path: __dirname + '/../tmp/umzug.json' }
           });
         });
@@ -33,7 +42,7 @@ describe('Umzug', function () {
         expect(this.migrations).to.be.an(Array);
       });
 
-      it('returns 0 items', function () {
+      it('returns 0 migrations', function () {
         expect(this.migrations).to.have.length(0);
       });
     });
@@ -54,7 +63,7 @@ describe('Umzug', function () {
         expect(this.migrations).to.be.an(Array);
       });
 
-      it('returns 1 items', function () {
+      it('returns 1 migration', function () {
         expect(this.migrations).to.have.length(1);
         expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
       });
@@ -76,7 +85,7 @@ describe('Umzug', function () {
         expect(this.migrations).to.be.an(Array);
       });
 
-      it('returns 3 items', function () {
+      it('returns 3 migrations', function () {
         expect(this.migrations).to.have.length(3);
         expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
         expect(this.migrations[1].file).to.equal(this.migrationNames[1] + '.js');
@@ -102,11 +111,10 @@ describe('Umzug', function () {
         expect(this.migrations).to.be.an(Array);
       });
 
-      it('returns 1 items', function () {
+      it('returns 1 migration', function () {
         expect(this.migrations).to.have.length(1);
         expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
       });
     });
-
   });
 });

--- a/test/index/executed.test.js
+++ b/test/index/executed.test.js
@@ -8,9 +8,11 @@ describe('Umzug', function () {
   describe('executed', function () {
     beforeEach(function () {
       return helper
-        .prepareMigrations(3)
+        .prepare({
+          migrations: { count: 3 }
+        })
         .bind(this)
-        .then(function (migrationNames) {
+        .spread(function (migrationNames) {
           this.migrationNames = migrationNames;
           this.umzug          = new Umzug({
             migrations:     { path: __dirname + '/../tmp/' },

--- a/test/index/pending.test.js
+++ b/test/index/pending.test.js
@@ -9,9 +9,11 @@ describe('Umzug', function () {
   describe('pending', function () {
     beforeEach(function () {
       return helper
-        .prepareMigrations(3)
+        .prepare({
+          migrations: { count: 3 }
+        })
         .bind(this)
-        .then(function (migrationNames) {
+        .spread(function (migrationNames) {
           this.migrationNames = migrationNames;
           this.umzug          = new Umzug({
             migrations:     { path: __dirname + '/../tmp/' },

--- a/test/index/pending.test.js
+++ b/test/index/pending.test.js
@@ -2,7 +2,6 @@
 
 var expect    = require('expect.js');
 var helper    = require('../helper');
-var Migration = require('../../lib/migration');
 var Umzug     = require('../../index');
 
 describe('Umzug', function () {
@@ -10,13 +9,22 @@ describe('Umzug', function () {
     beforeEach(function () {
       return helper
         .prepare({
-          migrations: { count: 3 }
+          migrations: { count: 3 },
+          squashes:   { count: 3, options: {
+            migrations: [
+              [ '1-migration.js', '2-migration.js' ],
+              [ '2-migration.js', '3-migration.js' ],
+              [ '1-migration.js', '2-migration.js', '3-migration.js' ]
+            ]
+          }}
         })
         .bind(this)
-        .spread(function (migrationNames) {
+        .spread(function (migrationNames, squashNames) {
           this.migrationNames = migrationNames;
+          this.squashNames = squashNames;
           this.umzug          = new Umzug({
             migrations:     { path: __dirname + '/../tmp/' },
+            squashes:       { path: __dirname + '/../tmp/squashes/' },
             storageOptions: { path: __dirname + '/../tmp/umzug.json' }
           });
         });
@@ -33,14 +41,11 @@ describe('Umzug', function () {
         expect(this.migrations).to.be.an(Array);
       });
 
-      it('returns 3 items', function () {
+      it('returns 3 migrations', function () {
         expect(this.migrations).to.have.length(3);
-      });
-
-      it('returns migration instances', function () {
-        this.migrations.forEach(function (migration) {
-          expect(migration).to.be.a(Migration);
-        });
+        expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+        expect(this.migrations[1].file).to.equal(this.migrationNames[1] + '.js');
+        expect(this.migrations[2].file).to.equal(this.migrationNames[2] + '.js');
       });
     });
 
@@ -56,22 +61,20 @@ describe('Umzug', function () {
         });
       });
 
-      it('returns only 2 items', function () {
+      it('returns only 2 migrations', function () {
         expect(this.migrations).to.have.length(2);
+        expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+        expect(this.migrations[1].file).to.equal(this.migrationNames[2] + '.js');
       });
 
       it('returns only the migrations that have not been run yet', function () {
-        var self = this;
-
-        this.migrationNames.slice(1).forEach(function (migrationName, i) {
-          expect(self.migrations[i].file).to.equal(migrationName + '.js');
-        });
+        expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+        expect(this.migrations[1].file).to.equal(this.migrationNames[2] + '.js');
       });
     });
 
     describe('when storage returns a thenable', function () {
       beforeEach(function () {
-
         //a migration has been executed already
         return this.umzug.execute({
           migrations: [ this.migrationNames[0] ],
@@ -87,16 +90,15 @@ describe('Umzug', function () {
         });
       });
 
-      it('returns only 2 items', function () {
+      it('returns only 2 migrations', function () {
         expect(this.migrations).to.have.length(2);
+        expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+        expect(this.migrations[1].file).to.equal(this.migrationNames[2] + '.js');
       });
 
       it('returns only the migrations that have not been run yet', function () {
-        var self = this;
-
-        this.migrationNames.slice(1).forEach(function (migrationName, i) {
-          expect(self.migrations[i].file).to.equal(migrationName + '.js');
-        });
+        expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+        expect(this.migrations[1].file).to.equal(this.migrationNames[2] + '.js');
       });
     });
   });

--- a/test/index/up.test.js
+++ b/test/index/up.test.js
@@ -8,293 +8,603 @@ var Umzug     = require('../../index');
 
 describe('Umzug', function () {
   describe('up', function () {
-    beforeEach(function () {
-      return helper
-        .prepare({
-          migrations: { count: 3 }
-        })
-        .bind(this)
-        .spread(function (migrationNames) {
-          this.migrationNames = migrationNames;
-          this.umzug          = new Umzug({
-            migrations:     { path: __dirname + '/../tmp/' },
-            storageOptions: { path: __dirname + '/../tmp/umzug.json' }
-          });
-        });
-    });
-
-    describe('when no migrations has been executed yet', function () {
+    describe('without squashes', function () {
       beforeEach(function () {
-        return this.umzug.up().bind(this).then(function (migrations) {
-          this.migrations = migrations;
-        });
-      });
-
-      it('returns an array', function () {
-        expect(this.migrations).to.be.an(Array);
-      });
-
-      it('returns 3 items', function () {
-        expect(this.migrations).to.have.length(3);
-      });
-
-      it('returns migration instances', function () {
-        this.migrations.forEach(function (migration) {
-          expect(migration).to.be.a(Migration);
-        });
-      });
-    });
-
-    describe('when a migration has been executed already', function () {
-      beforeEach(function () {
-        return this.umzug.execute({
-          migrations: [ this.migrationNames[0] ],
-          method:     'up'
-        }).bind(this).then(function () {
-          return this.umzug.up();
-        }).then(function (migrations) {
-          this.migrations = migrations;
-        });
-      });
-
-      it('returns only 2 items', function () {
-        expect(this.migrations).to.have.length(2);
-      });
-
-      it('returns only the migrations that have not been run yet', function () {
-        var self = this;
-
-        this.migrationNames.slice(1).forEach(function (migrationName, i) {
-          expect(self.migrations[i].file).to.equal(migrationName + '.js');
-        });
-      });
-
-      it('adds the two missing migrations to the storage', function () {
-        return this.umzug.executed().then(function (migrations) {
-          expect(migrations).to.have.length(3);
-        });
-      });
-    });
-
-    describe('when passing the `to` option', function () {
-      beforeEach(function () {
-        return this.umzug.up({
-          to: this.migrationNames[1]
-        }).bind(this).then(function (migrations) {
-          this.migrations = migrations;
-        });
-      });
-
-      it('returns only 2 migrations', function () {
-        expect(this.migrations).to.have.length(2);
-      });
-
-      it('executed only the first 2 migrations', function () {
-        return this.umzug.executed().then(function (migrations) {
-          expect(migrations).to.have.length(2);
-        });
-      });
-
-      it('did not execute the third migration', function () {
-        return this.umzug.executed()
-          .bind(this).then(function (migrations) {
-            var migrationFiles = migrations.map(function (migration) {
-              return migration.file;
+        return helper
+          .prepare({
+            migrations: { count: 3 }
+          })
+          .bind(this)
+          .spread(function (migrationNames) {
+            this.migrationNames = migrationNames;
+            this.umzug = new Umzug({
+              migrations:     { path: __dirname + '/../tmp/' },
+              storageOptions: { path: __dirname + '/../tmp/umzug.json' }
             });
-            expect(migrationFiles).to.not.contain(this.migrationNames[2]);
           });
       });
 
-      describe('that does not match a migration', function () {
-        it('rejects the promise', function () {
-          return this.umzug.up({ to: '123-asdasd' }).then(function () {
-            return Bluebird.reject('We should not end up here...');
-          }, function (err) {
-            expect(err.message).to.equal('Unable to find migration: 123-asdasd');
-          });
-        });
-      });
-
-      describe('that does not match a pending migration', function () {
-        it('rejects the promise', function () {
-          return this.umzug
-            .execute({ migrations: this.migrationNames, method: 'up' })
-            .bind(this)
-            .then(function () {
-              return this.umzug.up({ to: this.migrationNames[1] });
-            })
-            .then(function () {
-              return Bluebird.reject('We should not end up here...');
-            }, function (err) {
-              expect(err.message).to.equal('Migration is not pending: 2-migration.js');
-            });
-        });
-      });
-    });
-
-    describe('when called with a string', function () {
-      describe('that matches a pending migration', function () {
+      describe('when no migrations has been executed yet', function () {
         beforeEach(function () {
-          return this.umzug.up(this.migrationNames[1]).bind(this)
-            .then(function (migrations) { this.migrations = migrations; });
+          return this.umzug.up().bind(this).then(function (migrations) {
+            this.migrations = migrations;
+          });
         });
 
-        it('returns only 1 migrations', function () {
-          expect(this.migrations).to.have.length(1);
+        it('returns an array', function () {
+          expect(this.migrations).to.be.an(Array);
         });
 
-        it('executed only the second migrations', function () {
-          return this.umzug.executed().bind(this).then(function (migrations) {
-            expect(migrations).to.have.length(1);
-            expect(migrations[0].testFileName(this.migrationNames[1])).to.be.ok();
+        it('returns 3 items', function () {
+          expect(this.migrations).to.have.length(3);
+        });
+
+        it('returns migration instances', function () {
+          this.migrations.forEach(function (migration) {
+            expect(migration).to.be.a(Migration);
+            expect(migration.migrations()).to.be.an(Array);
+            expect(migration.migrations()).to.have.length(1);
           });
         });
       });
 
-      describe('that does not match a migration', function () {
-        it('rejects the promise', function () {
-          return this.umzug.up('123-asdasd').then(function () {
-            return Bluebird.reject('We should not end up here...');
-          }, function (err) {
-            expect(err.message).to.equal('Unable to find migration: 123-asdasd');
-          });
-        });
-      });
-
-      describe('that does not match a pending migration', function () {
-        it('rejects the promise', function () {
-          return this.umzug
-            .execute({ migrations: this.migrationNames, method: 'up' })
-            .bind(this)
-            .then(function () {
-              return this.umzug.up(this.migrationNames[1]);
-            })
-            .then(function () {
-              return Bluebird.reject('We should not end up here...');
-            }, function (err) {
-              expect(err.message).to.equal('Migration is not pending: 2-migration.js');
-            });
-        });
-      });
-    });
-
-    describe('when called with an array', function () {
-      describe('that matches a pending migration', function () {
+      describe('when a migration has been executed already', function () {
         beforeEach(function () {
-          return this.umzug.up([this.migrationNames[1]]).bind(this)
-            .then(function (migrations) { this.migrations = migrations; });
+          return this.umzug.execute({
+            migrations: [this.migrationNames[0]],
+            method: 'up'
+          }).bind(this).then(function () {
+            return this.umzug.up();
+          }).then(function (migrations) {
+            this.migrations = migrations;
+          });
         });
 
-        it('returns only 1 migrations', function () {
-          expect(this.migrations).to.have.length(1);
+        it('returns only 2 items', function () {
+          expect(this.migrations).to.have.length(2);
         });
 
-        it('executed only the second migrations', function () {
-          return this.umzug.executed().bind(this).then(function (migrations) {
-            expect(migrations).to.have.length(1);
-            expect(migrations[0].testFileName(this.migrationNames[1])).to.be.ok();
+        it('returns only the migrations that have not been run yet', function () {
+          var self = this;
+
+          this.migrationNames.slice(1).forEach(function (migrationName, i) {
+            expect(self.migrations[i].file).to.equal(migrationName + '.js');
+          });
+        });
+
+        it('adds the two missing migrations to the storage', function () {
+          return this.umzug.executed().then(function (migrations) {
+            expect(migrations).to.have.length(3);
           });
         });
       });
 
-      describe('that matches multiple pending migration', function () {
+      describe('when passing the `to` option', function () {
         beforeEach(function () {
-          return this.umzug.up(this.migrationNames.slice(1)).bind(this)
-            .then(function (migrations) { this.migrations = migrations; });
+          return this.umzug.up({
+            to: this.migrationNames[1]
+          }).bind(this).then(function (migrations) {
+            this.migrations = migrations;
+          });
         });
 
         it('returns only 2 migrations', function () {
           expect(this.migrations).to.have.length(2);
+          expect(this.migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+          expect(this.migrations[1].file).to.equal(this.migrationNames[1] + '.js');
         });
 
-        it('executed only the second and the third migrations', function () {
-          return this.umzug.executed().bind(this).then(function (migrations) {
+        it('executed only the first 2 migrations', function () {
+          return this.umzug.executed().then(function (migrations) {
             expect(migrations).to.have.length(2);
-            expect(migrations[0].testFileName(this.migrationNames[1])).to.be.ok();
-            expect(migrations[1].testFileName(this.migrationNames[2])).to.be.ok();
+          });
+        });
+
+        it('did not execute the third migration', function () {
+          return this.umzug.executed()
+            .bind(this).then(function (migrations) {
+              var migrationFiles = migrations.map(function (migration) {
+                return migration.file;
+              });
+              expect(migrationFiles).to.not.contain(this.migrationNames[2]);
+            });
+        });
+
+        describe('that does not match a migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug.up({to: '123-asdasd'}).then(function () {
+              return Bluebird.reject('We should not end up here...');
+            }, function (err) {
+              expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+            });
+          });
+        });
+
+        describe('that does not match a pending migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({migrations: this.migrationNames, method: 'up'})
+              .bind(this)
+              .then(function () {
+                return this.umzug.up({to: this.migrationNames[1]});
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration is not pending: 2-migration.js');
+              });
           });
         });
       });
 
-      describe('that does not match a migration', function () {
-        it('rejects the promise', function () {
-          return this.umzug.up(['123-asdasd']).then(function () {
-            return Bluebird.reject('We should not end up here...');
-          }, function (err) {
-            expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+      describe('when called with a string', function () {
+        describe('that matches a pending migration', function () {
+          beforeEach(function () {
+            return this.umzug.up(this.migrationNames[1]).bind(this)
+              .then(function (migrations) {
+                this.migrations = migrations;
+              });
+          });
+
+          it('returns only 1 migration', function () {
+            expect(this.migrations).to.have.length(1);
+            expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+          });
+
+          it('executed only the second migrations', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(1);
+              expect(migrations[0].testFileName(this.migrationNames[1])).to.be.ok();
+            });
+          });
+        });
+
+        describe('that does not match a migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug.up('123-asdasd').then(function () {
+              return Bluebird.reject('We should not end up here...');
+            }, function (err) {
+              expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+            });
+          });
+        });
+
+        describe('that does not match a pending migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({migrations: this.migrationNames, method: 'up'})
+              .bind(this)
+              .then(function () {
+                return this.umzug.up(this.migrationNames[1]);
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration is not pending: 2-migration.js');
+              });
           });
         });
       });
 
-      describe('that does not match a pending migration', function () {
-        it('rejects the promise', function () {
-          return this.umzug
-            .execute({ migrations: this.migrationNames, method: 'up' })
-            .bind(this)
-            .then(function () {
-              return this.umzug.up([this.migrationNames[1]]);
-            })
-            .then(function () {
+      describe('when called with an array', function () {
+        describe('that matches a pending migration', function () {
+          beforeEach(function () {
+            return this.umzug.up([this.migrationNames[1]]).bind(this)
+              .then(function (migrations) {
+                this.migrations = migrations;
+              });
+          });
+
+          it('returns only 1 migration', function () {
+            expect(this.migrations).to.have.length(1);
+            expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+          });
+
+          it('executed only the second migrations', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(1);
+              expect(migrations[0].testFileName(this.migrationNames[1])).to.be.ok();
+            });
+          });
+        });
+
+        describe('that matches multiple pending migration', function () {
+          beforeEach(function () {
+            return this.umzug.up(this.migrationNames.slice(1)).bind(this)
+              .then(function (migrations) {
+                this.migrations = migrations;
+              });
+          });
+
+          it('returns only 2 migrations', function () {
+            expect(this.migrations).to.have.length(2);
+            expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+            expect(this.migrations[1].file).to.equal(this.migrationNames[2] + '.js');
+          });
+
+          it('executed only the second and the third migrations', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(2);
+              expect(migrations[0].testFileName(this.migrationNames[1])).to.be.ok();
+              expect(migrations[1].testFileName(this.migrationNames[2])).to.be.ok();
+            });
+          });
+        });
+
+        describe('that does not match a migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug.up(['123-asdasd']).then(function () {
               return Bluebird.reject('We should not end up here...');
             }, function (err) {
-              expect(err.message).to.equal('Migration is not pending: 2-migration.js');
+              expect(err.message).to.equal('Unable to find migration: 123-asdasd');
             });
+          });
+        });
+
+        describe('that does not match a pending migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({migrations: this.migrationNames, method: 'up'})
+              .bind(this)
+              .then(function () {
+                return this.umzug.up([this.migrationNames[1]]);
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration is not pending: 2-migration.js');
+              });
+          });
+        });
+
+        describe('that does partially not match a pending migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({
+                migrations: this.migrationNames.slice(0, 2),
+                method: 'up'
+              })
+              .bind(this)
+              .then(function () {
+                return this.umzug.up(this.migrationNames.slice(1));
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration is not pending: 2-migration.js');
+              });
+          });
         });
       });
 
-      describe('that does partially not match a pending migration', function () {
-        it('rejects the promise', function () {
-          return this.umzug
-            .execute({ migrations: this.migrationNames.slice(0, 2), method: 'up' })
-            .bind(this)
-            .then(function () {
-              return this.umzug.up(this.migrationNames.slice(1));
-            })
-            .then(function () {
-              return Bluebird.reject('We should not end up here...');
-            }, function (err) {
-              expect(err.message).to.equal('Migration is not pending: 2-migration.js');
-            });
+      describe('when storage returns a thenable', function () {
+        beforeEach(function () {
+
+          //one migration has been executed already
+          return this.umzug.execute({
+            migrations: [this.migrationNames[0]],
+            method: 'up'
+          }).bind(this).then(function () {
+
+            //storage returns a thenable
+            this.umzug.storage = helper.wrapStorageAsCustomThenable(this.umzug.storage);
+
+            return this.umzug.up();
+          }).then(function (migrations) {
+            this.migrations = migrations;
+          });
+        });
+
+        it('returns only 2 items', function () {
+          expect(this.migrations).to.have.length(2);
+        });
+
+        it('returns only the migrations that have not been run yet', function () {
+          var self = this;
+
+          this.migrationNames.slice(1).forEach(function (migrationName, i) {
+            expect(self.migrations[i].file).to.equal(migrationName + '.js');
+          });
+        });
+
+        it('adds the two missing migrations to the storage', function () {
+          return this.umzug.executed().then(function (migrations) {
+            expect(migrations).to.have.length(3);
+          });
         });
       });
     });
 
-    describe('when storage returns a thenable', function () {
+    describe('with squashes', function () {
       beforeEach(function () {
+        return helper
+          .prepare({
+            migrations: { count: 3 },
+            squashes:   { count: 3, options: {
+              migrations: [
+                [ '1-migration.js', '2-migration.js' ],
+                [ '2-migration.js', '3-migration.js' ],
+                [ '1-migration.js', '2-migration.js', '3-migration.js' ]
+              ]
+            }}
+          })
+          .bind(this)
+          .spread(function (migrationNames, squashNames) {
+            this.migrationNames = migrationNames;
+            this.squashNames = squashNames;
+            this.umzug = new Umzug({
+              migrations:     { path: __dirname + '/../tmp/' },
+              squashes:       { path: __dirname + '/../tmp/squashes/' },
+              storageOptions: { path: __dirname + '/../tmp/umzug.json' }
+            });
+          });
+      });
 
-        //one migration has been executed already
-        return this.umzug.execute({
-          migrations: [ this.migrationNames[0] ],
-          method:     'up'
-        }).bind(this).then(function () {
+      describe('when no migrations has been executed yet', function () {
+        beforeEach(function () {
+          return this.umzug.up().bind(this).then(function (migrations) {
+            this.migrations = migrations;
+          });
+        });
 
-          //storage returns a thenable
-          this.umzug.storage = helper.wrapStorageAsCustomThenable(this.umzug.storage);
+        it('returns an array', function () {
+          expect(this.migrations).to.be.an(Array);
+        });
 
-          return this.umzug.up();
-        }).then(function (migrations) {
-          this.migrations = migrations;
+        it('returns 1 squash', function () {
+          expect(this.migrations).to.have.length(1);
+          expect(this.migrations[0].file).to.equal(this.squashNames[2] + '.js');
         });
       });
 
-      it('returns only 2 items', function () {
-        expect(this.migrations).to.have.length(2);
-      });
+      describe('when a migration has been executed already', function () {
+        beforeEach(function () {
+          return this.umzug.execute({
+            migrations: [this.migrationNames[0]],
+            method: 'up'
+          }).bind(this).then(function () {
+            return this.umzug.up();
+          }).then(function (migrations) {
+            this.migrations = migrations;
+          });
+        });
 
-      it('returns only the migrations that have not been run yet', function () {
-        var self = this;
+        it('returns only 1 squash', function () {
+          expect(this.migrations).to.have.length(1);
+          expect(this.migrations[0].file).to.equal(this.squashNames[1] + '.js');
+        });
 
-        this.migrationNames.slice(1).forEach(function (migrationName, i) {
-          expect(self.migrations[i].file).to.equal(migrationName + '.js');
+        it('adds the two missing migrations to the storage', function () {
+          return this.umzug.executed().then(function (migrations) {
+            expect(migrations).to.have.length(3);
+          });
         });
       });
 
-      it('adds the two missing migrations to the storage', function () {
-        return this.umzug.executed().then(function (migrations) {
-          expect(migrations).to.have.length(3);
+      describe('when passing the `to` option', function () {
+        beforeEach(function () {
+          return this.umzug.up({
+            to: this.migrationNames[1]
+          }).bind(this).then(function (migrations) {
+            this.migrations = migrations;
+          });
+        });
+
+        it('returns only 1 squash', function () {
+          expect(this.migrations).to.have.length(1);
+          expect(this.migrations[0].file).to.equal(this.squashNames[0] + '.js');
+        });
+
+        it('executed only the first 2 migrations', function () {
+          return this.umzug.executed().then(function (migrations) {
+            expect(migrations).to.have.length(2);
+          });
+        });
+
+        it('did not execute the third migration', function () {
+          return this.umzug.executed()
+            .bind(this).then(function (migrations) {
+              var migrationFiles = migrations.map(function (migration) {
+                return migration.file;
+              });
+              expect(migrationFiles).to.not.contain(this.migrationNames[2]);
+            });
+        });
+
+        describe('that does not match a migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug.up({to: '123-asdasd'}).then(function () {
+              return Bluebird.reject('We should not end up here...');
+            }, function (err) {
+              expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+            });
+          });
+        });
+
+        describe('that does not match a pending migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({migrations: this.migrationNames, method: 'up'})
+              .bind(this)
+              .then(function () {
+                return this.umzug.up({to: this.migrationNames[1]});
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration is not pending: 2-migration.js');
+              });
+          });
+        });
+      });
+
+      describe('when called with a string', function () {
+        describe('that matches a pending migration', function () {
+          beforeEach(function () {
+            return this.umzug.up(this.migrationNames[1]).bind(this)
+              .then(function (migrations) {
+                this.migrations = migrations;
+              });
+          });
+
+          it('returns only 1 migrations', function () {
+            expect(this.migrations).to.have.length(1);
+            expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+          });
+
+          it('executed only the second migrations', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(1);
+              expect(migrations[0].testFileName(this.migrationNames[1])).to.be.ok();
+            });
+          });
+        });
+
+        describe('that does not match a migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug.up('123-asdasd').then(function () {
+              return Bluebird.reject('We should not end up here...');
+            }, function (err) {
+              expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+            });
+          });
+        });
+
+        describe('that does not match a pending migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({migrations: this.migrationNames, method: 'up'})
+              .bind(this)
+              .then(function () {
+                return this.umzug.up(this.migrationNames[1]);
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration is not pending: 2-migration.js');
+              });
+          });
+        });
+      });
+
+      describe('when called with an array', function () {
+        describe('that matches a pending migration', function () {
+          beforeEach(function () {
+            return this.umzug.up([this.migrationNames[1]]).bind(this)
+              .then(function (migrations) {
+                this.migrations = migrations;
+              });
+          });
+
+          it('returns only 1 migration', function () {
+            expect(this.migrations).to.have.length(1);
+            expect(this.migrations[0].file).to.equal(this.migrationNames[1] + '.js');
+          });
+
+          it('executed only the second migrations', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(1);
+              expect(migrations[0].testFileName(this.migrationNames[1])).to.be.ok();
+            });
+          });
+        });
+
+        describe('that matches multiple pending migration', function () {
+          beforeEach(function () {
+            return this.umzug.up(this.migrationNames.slice(1)).bind(this)
+              .then(function (migrations) {
+                this.migrations = migrations;
+              });
+          });
+
+          it('returns only 1 squash', function () {
+            expect(this.migrations).to.have.length(1);
+            expect(this.migrations[0].file).to.equal(this.squashNames[1] + '.js');
+          });
+
+          it('executed only the second and the third migrations', function () {
+            return this.umzug.executed().bind(this).then(function (migrations) {
+              expect(migrations).to.have.length(2);
+              expect(migrations[0].testFileName(this.migrationNames[1])).to.be.ok();
+              expect(migrations[1].testFileName(this.migrationNames[2])).to.be.ok();
+            });
+          });
+        });
+
+        describe('that does not match a migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug.up(['123-asdasd']).then(function () {
+              return Bluebird.reject('We should not end up here...');
+            }, function (err) {
+              expect(err.message).to.equal('Unable to find migration: 123-asdasd');
+            });
+          });
+        });
+
+        describe('that does not match a pending migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({migrations: this.migrationNames, method: 'up'})
+              .bind(this)
+              .then(function () {
+                return this.umzug.up([this.migrationNames[1]]);
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration is not pending: 2-migration.js');
+              });
+          });
+        });
+
+        describe('that does partially not match a pending migration', function () {
+          it('rejects the promise', function () {
+            return this.umzug
+              .execute({
+                migrations: this.migrationNames.slice(0, 2),
+                method: 'up'
+              })
+              .bind(this)
+              .then(function () {
+                return this.umzug.up(this.migrationNames.slice(1));
+              })
+              .then(function () {
+                return Bluebird.reject('We should not end up here...');
+              }, function (err) {
+                expect(err.message).to.equal('Migration is not pending: 2-migration.js');
+              });
+          });
+        });
+      });
+
+      describe('when storage returns a thenable', function () {
+        beforeEach(function () {
+          //one migration has been executed already
+          return this.umzug.execute({
+            migrations: [this.migrationNames[0]],
+            method: 'up'
+          }).bind(this).then(function () {
+
+            //storage returns a thenable
+            this.umzug.storage = helper.wrapStorageAsCustomThenable(this.umzug.storage);
+
+            return this.umzug.up();
+          }).then(function (migrations) {
+            this.migrations = migrations;
+          });
+        });
+
+        it('returns only 1 squash', function () {
+          expect(this.migrations).to.have.length(1);
+          expect(this.migrations[0].file).to.equal(this.squashNames[1] + '.js');
+        });
+
+        it('adds the two missing migrations to the storage', function () {
+          return this.umzug.executed().then(function (migrations) {
+            expect(migrations).to.have.length(3);
+          });
         });
       });
     });
-
   });
 });

--- a/test/index/up.test.js
+++ b/test/index/up.test.js
@@ -10,9 +10,11 @@ describe('Umzug', function () {
   describe('up', function () {
     beforeEach(function () {
       return helper
-        .prepareMigrations(3)
+        .prepare({
+          migrations: { count: 3 }
+        })
         .bind(this)
-        .then(function (migrationNames) {
+        .spread(function (migrationNames) {
           this.migrationNames = migrationNames;
           this.umzug          = new Umzug({
             migrations:     { path: __dirname + '/../tmp/' },

--- a/test/storages/json.test.js
+++ b/test/storages/json.test.js
@@ -29,7 +29,9 @@ describe('storages', function () {
         this.storage = new Storage({
           storageOptions: { path: this.path }
         });
-        return helper.prepareMigrations(3);
+        return helper.prepare({
+          migrations: { count: 3 }
+        });
       });
 
       it('creates a new file if not exists yet', function () {
@@ -56,7 +58,9 @@ describe('storages', function () {
         this.storage = new Storage({
           storageOptions: { path: this.path }
         });
-        return helper.prepareMigrations(3);
+        return helper.prepare({
+          migrations: { count: 3 }
+        });
       });
 
       it('removes the passed value from the storage', function () {
@@ -91,7 +95,9 @@ describe('storages', function () {
         this.storage = new Storage({
           storageOptions: { path: this.path }
         });
-        return helper.prepareMigrations(3);
+        return helper.prepare({
+          migrations: { count: 3 }
+        });
       });
 
       it('returns an empty array if no migrations were logged yet', function () {


### PR DESCRIPTION
Sorry for too large commit. :smile: There is still one open question:

How should we handle squashes with interrupted queue of migrations? That's we have a squash for migrations `20151208080000.js` and `20151208120000.js` but later someone publishes a migration `20151208100000.js`. Currently, the squash cannot be applied at all because it was not clear to me if the squash should be run before that migration or vice versa.