### PR TITLE
New storage type that stores nothing

### DIFF
--- a/lib/storages/none.js
+++ b/lib/storages/none.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var Bluebird  = require('bluebird');
+var redefine  = require('redefine');
+
+module.exports = redefine.Class({
+  constructor: function (options) {},
+
+  logMigration: function (migrationName) {
+    return Bluebird.resolve();
+  },
+
+  unlogMigration: function (migrationName) {
+    return Bluebird.resolve();
+  },
+
+  executed: function () {
+    return Bluebird.resolve([]);
+  }
+});

--- a/test/storages/none.test.js
+++ b/test/storages/none.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var expect    = require('expect.js');
+var helper    = require('../helper');
+var Storage   = require('../../lib/storages/none');
+
+describe('storages', function () {
+
+  describe('none', function () {
+
+    describe('constructor', function () {
+
+      it('stores no options', function () {
+        var storage = new Storage();
+        expect(storage).to.not.have.property('options');
+      });
+
+    });
+
+    describe('executed', function () {
+
+      beforeEach(function () {
+        this.storage = new Storage();
+        return helper.prepareMigrations(3);
+      });
+
+      it('returns an empty array', function () {
+        return this.storage.executed().then(function (data) {
+          expect(data).to.eql([]);
+        });
+      });
+
+      it('returns an empty array even if migrations were executed', function () {
+        return this.storage.logMigration('foo.js').bind(this).then(function () {
+          return this.storage.executed();
+        }).then(function (data) {
+          expect(data).to.eql([]);
+        });
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Trying to change sequelize cli seeder to work as a seeder should. This requires that the seeding tasks not be registered, so I created this empty storage type.