### PR TITLE
Support running migrations on utf8mb4 databases

### DIFF
--- a/lib/storages/sequelize.js
+++ b/lib/storages/sequelize.js
@@ -74,7 +74,8 @@ module.exports = redefine.Class({
           {
             tableName:  this.options.storageOptions.tableName,
             schema: this.options.storageOptions.schema,
-            timestamps: false
+            timestamps: false,
+            collate: 'utf8_unicode_ci'
           }
         );
       }


### PR DESCRIPTION
Without this, running a migration on a utf8mb4 database returns the error "Error: ER_TOO_LONG_KEY: Specified key was too long; max key length is 767 bytes" on the migration name column.

Resolves #31 