### PR TITLE
Set charset for SequelizeMeta table utf8

### DIFF
--- a/lib/storages/sequelize.js
+++ b/lib/storages/sequelize.js
@@ -75,6 +75,7 @@ module.exports = redefine.Class({
             tableName:  this.options.storageOptions.tableName,
             schema: this.options.storageOptions.schema,
             timestamps: false,
+            charset: 'utf8',
             collate: 'utf8_unicode_ci'
           }
         );


### PR DESCRIPTION
As stated in https://github.com/sequelize/umzug/issues/46, when set the define value in the sequelize config file as 
```
{
  "define": {
     "charset": "utf8mb4",
      "collate": "utf8mb4_general_ci",
   }
}
```
it throws error in running migration:
```
{ [SequelizeDatabaseError: ER_COLLATION_CHARSET_MISMATCH: COLLATION 'utf8_unicode_ci' is not valid for CHARACTER SET 'utf8mb4']
  name: 'SequelizeDatabaseError',
  message: 'ER_COLLATION_CHARSET_MISMATCH: COLLATION \'utf8_unicode_ci\' is not valid for CHARACTER SET \'utf8mb4\'',
  parent:
   { [Error: ER_COLLATION_CHARSET_MISMATCH: COLLATION 'utf8_unicode_ci' is not valid for CHARACTER SET 'utf8mb4']
     code: 'ER_COLLATION_CHARSET_MISMATCH',
     errno: 1253,
     sqlState: '42000',
     index: 0,
     sql: 'CREATE TABLE IF NOT EXISTS `SequelizeMeta` (`name` VARCHAR(255) NOT NULL UNIQUE , PRIMARY KEY (`name`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8_unicode_ci;' },
  original:
   { [Error: ER_COLLATION_CHARSET_MISMATCH: COLLATION 'utf8_unicode_ci' is not valid for CHARACTER SET 'utf8mb4']
     code: 'ER_COLLATION_CHARSET_MISMATCH',
     errno: 1253,
     sqlState: '42000',
     index: 0,
     sql: 'CREATE TABLE IF NOT EXISTS `SequelizeMeta` (`name` VARCHAR(255) NOT NULL UNIQUE , PRIMARY KEY (`name`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8_unicode_ci;' },
  sql: 'CREATE TABLE IF NOT EXISTS `SequelizeMeta` (`name` VARCHAR(255) NOT NULL UNIQUE , PRIMARY KEY (`name`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8_unicode_ci;' }
```

This was due to SequelizeMeta table uses collate `utf8_unicode_ci` while it uses charset `utf8mb4`. This PR makes the table always use charset `utf8`.