### PR TITLE
update docs: you can't pass instances as `storage:`

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ It is possible to configure *umzug* instance via passing an object to the constr
 ```js
 {
   // The storage.
-  // Possible values: 'json', 'sequelize', an object
+  // Possible values: 'json', 'sequelize', an argument for `require()`, including absolute paths
   storage: 'json',
 
   // The options for the storage.


### PR DESCRIPTION
If you try, this happens:

```sh 
     throw new Error('Unable to resolve the storage: ' + this.options.storage);
      ^

Error: Unable to resolve the storage: [object Object]
```