### PR TITLE
Extracted common parts of `up` and `down` to new `_run`

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,9 @@ var Umzug = module.exports = redefine.Class({
 
     if (typeof options === 'undefined') {
       return getExecuted().bind(this).then(function (migrations) {
-        return migrations[0] ? this.down(migrations[0].file) : Bluebird.resolve([]);
+        return migrations[0]
+          ? this.down(migrations[0].file)
+          : Bluebird.resolve([]);
       });
     } else {
       return this._run(false, options, getExecuted.bind(this));


### PR DESCRIPTION
Refactored `up` and `down` methods since they have had a lot of common code. Diff is not showing changes in the best way, so I'll explain it shortly. There is now `_run(bool: up, any: options, fn: rest)` and `up` is calling it as `this._run(true, options, this.pending.bind(this))` while `down` calls it as `this._run(false, options, getExecuted.bind(this))`.