### PR TITLE
Fixed #50; `down({})` reverts only the latest migration

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ var Umzug = module.exports = redefine.Class({
       });
     }.bind(this);
 
-    if (typeof options === 'undefined') {
+    if (typeof options === 'undefined' || _.isEqual(options, {})) {
       return getExecuted().bind(this).then(function (migrations) {
         return migrations[0]
           ? this.down(migrations[0].file)

--- a/test/index/down.test.js
+++ b/test/index/down.test.js
@@ -96,6 +96,27 @@ describe('down', function () {
       });
     });
 
+    describe('when empty options is specified', function () {
+      beforeEach(function () {
+        return this.umzug.down({}).bind(this).then(function (migrations) {
+          this.migrations = migrations;
+        });
+      });
+
+      it('returns 1 item', function () {
+        expect(this.migrations).to.have.length(1);
+        expect(this.migrations[0].file).to.equal(this.migrationNames[2] + '.js');
+      });
+
+      it('removes the reverted migrations from the storage', function () {
+        return this.umzug.executed().bind(this).then(function (migrations) {
+          expect(migrations).to.have.length(2);
+          expect(migrations[0].file).to.equal(this.migrationNames[0] + '.js');
+          expect(migrations[1].file).to.equal(this.migrationNames[1] + '.js');
+        });
+      });
+    });
+
     describe('when `to` option is passed', function () {
       beforeEach(function () {
         return this.umzug.down({


### PR DESCRIPTION
Fixing #50.