### PR TITLE
Fixed nesting of tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,7 @@ gulp.task('lint', function () {
 
 gulp.task('test', function () {
   gulp
-    .src(path.resolve(__dirname, 'test', '**', '*.js'), { read: false })
+    .src(path.resolve(__dirname, 'test', '**', 'index.js'), { read: false })
     .pipe(mocha({
        reporter:    'spec',
        ignoreLeaks: true,


### PR DESCRIPTION
Some test cases were required before corresponding `index.js` and therefore ran
outside their container. For example, _constructor_ were before beginning of
_Umzug_ in [test results][1]. See lines [389][2] and [471][3].

[1]: https://travis-ci.org/sequelize/umzug/jobs/117678313
[2]: https://travis-ci.org/sequelize/umzug/jobs/117678313#L389
[3]: https://travis-ci.org/sequelize/umzug/jobs/117678313#L471