### PR TITLE
Fixed tests to accept changed made in sequelize@3.15.1; Fixing #67

### DIFF
--- a/test/storages/sequelize.test.js
+++ b/test/storages/sequelize.test.js
@@ -53,7 +53,10 @@ describe('sequelize', function () {
         .then(function(description) {
           expect(description).to.only.have.keys(['name']);
           expect(description.name.type).to.eql('VARCHAR(255)');
-          expect(description.name.defaultValue).to.eql(null);
+          // expect(description.name.defaultValue).to.be.oneOf([null, undefined])
+          if (description.name.defaultValue !== undefined) {
+            expect(description.name.defaultValue).to.eql(null);
+          }
           expect(description.name.primaryKey).to.be.ok();
         });
     });
@@ -117,7 +120,10 @@ describe('sequelize', function () {
         })
         .then(function(description) {
           expect(description.name.type).to.eql('VARCHAR(190)');
-          expect(description.name.defaultValue).to.eql(null);
+          // expect(description.name.defaultValue).to.be.oneOf([null, undefined])
+          if (description.name.defaultValue !== undefined) {
+            expect(description.name.defaultValue).to.eql(null);
+          }
           expect(description.name.primaryKey).to.eql(true);
         });
     });


### PR DESCRIPTION
Sequelize@3.15.1 changes default `defaultValue` from `null` to `undefined` at
least for sqlite.

Another possible soolution is to delete these expections.

Fixing #67 