### PR TITLE
Fix upName / downName options being ignored

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -30,11 +30,11 @@ module.exports = redefine.Class({
   },
 
   up: function () {
-    return this._exec('up', [].slice.apply(arguments));
+    return this._exec(this.options.upName, [].slice.apply(arguments));
   },
 
   down: function () {
-    return this._exec('down', [].slice.apply(arguments));
+    return this._exec(this.options.downName, [].slice.apply(arguments));
   },
 
   testFileName: function (needle) {


### PR DESCRIPTION
This PR should fix the `upName` / `downName` options of `Umzug` being ignored. See #70. 