### PR TITLE
Introduce a 'from' option for up() method?

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,11 @@ umzug.up({ from: '20141101203500-task' }).then(function (migrations) {});
 
 In the above example umzug will execute all the pending migrations found **after** the specified migration. This is particularly usefull if you are using migrations on your native desktop application and you don't need to run past migrations on new installs while they need to run on updated installations.
 
+You can combine `from` and `to` options to select a specific subset:
+
+```js
+umzug.up({ from: '20141101203500-task', to: '20151201103412-items' }).then(function (migrations) {});
+```
 
 Running specific migrations while ignoring the right order, can be done like this:
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,15 @@ It is also possible to pass the name of a migration in order to just run the mig
 umzug.up({ to: '20141101203500-task' }).then(function (migrations) {});
 ```
 
+You also have the ability to choose to run migrations *from* a specific migration, excluding it:
+
+```js
+umzug.up({ from: '20141101203500-task' }).then(function (migrations) {});
+```
+
+In the above example umzug will execute all the pending migrations found **after** the specified migration. This is particularly usefull if you are using migrations on your native desktop application and you don't need to run past migrations on new installs while they need to run on updated installations.
+
+
 Running specific migrations while ignoring the right order, can be done like this:
 
 ```js

--- a/index.js
+++ b/index.js
@@ -251,10 +251,7 @@ var Umzug = module.exports = redefine.Class({
               return false;
             }
           });
-      })
-      .then(function(migrations) {
-        return migrations;
-      })      
+      });
   },
 
   log: function(message) {

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ var Umzug = module.exports = redefine.Class({
     } else if (Array.isArray(options)) {
       return Bluebird.resolve(options).bind(this)
         .map(function (migration) {
-          return this._findMigration(migration)
+          return this._findMigration(migration);
         })
         .then(function (migrations) {
           return method === 'up' ?
@@ -171,6 +171,7 @@ var Umzug = module.exports = redefine.Class({
 
     options = _.assign({
       to:         null,
+      from:       null,
       migrations: null
     }, options || {});
 
@@ -202,6 +203,13 @@ var Umzug = module.exports = redefine.Class({
             return Bluebird.resolve(migrations)
           });
         })
+        .then(function(migrations) {
+          if (options.from) {
+            return this._findMigrationsFromMatch(options.from, method);
+          } else {
+            return migrations;
+          }
+        })
         .then(function (migrations) {
           return this._findMigrationsUntilMatch(options.to, migrations);
         })
@@ -209,6 +217,47 @@ var Umzug = module.exports = redefine.Class({
           return this._run(method, { migrations: migrationFiles });
         });
     }
+  },
+
+  _findMigrationsFromMatch: function (from, method) {
+    // We'll fetch all migrations and work our way from start to finish
+    return this._findMigrations()
+      .bind(this)
+      .then(function(migrations) {
+
+        var found = false;
+        return migrations.filter(function(migration) {
+          if (migration.testFileName(from)) {
+            found = true;
+            return false;
+          }
+          return found;
+        });
+      })
+      .then(function(migrations) {
+        return migrations;
+      })
+      .filter(function(fromMigration) {
+        // now check if they need to be run based on status and method
+        return this._wasExecuted(fromMigration)
+          .then(function() {
+            if (method === 'up') {
+              return false;
+            } else {
+              return true;
+            }
+          })
+          .catch(function() {
+            if (method === 'up') {
+              return true;
+            } else {
+              return false;
+            }
+          });
+      })
+      .then(function(migrations) {
+        return migrations;
+      })      
   },
 
   log: function(message) {

--- a/index.js
+++ b/index.js
@@ -234,9 +234,6 @@ var Umzug = module.exports = redefine.Class({
           return found;
         });
       })
-      .then(function(migrations) {
-        return migrations;
-      })
       .filter(function(fromMigration) {
         // now check if they need to be run based on status and method
         return this._wasExecuted(fromMigration)

--- a/test/index/down.test.js
+++ b/test/index/down.test.js
@@ -117,6 +117,22 @@ describe('down', function () {
       });
     });
 
+    describe('when `from` option is passed', function () {
+      beforeEach(function () {
+        return this.umzug.down({
+          from: this.migrationNames[1],
+        }).bind(this).then(function (migrations) {
+          this.migrations = migrations;
+        });
+      });      
+      it('should return 1 migration', function () {
+        expect(this.migrations).to.have.length(1);
+      });
+      it('should be the last migration', function() {
+        expect(this.migrations[0].file).to.equal('3-migration.js');
+      });
+    });
+
     describe('when `to` option is passed', function () {
       beforeEach(function () {
         return this.umzug.down({

--- a/test/index/up.test.js
+++ b/test/index/up.test.js
@@ -73,6 +73,25 @@ describe('up', function () {
     });
   });
 
+
+  describe('when passing the `from` option', function () {
+    describe('UP method', function () {
+      beforeEach(function () {
+        return this.umzug.up({
+          from: this.migrationNames[1],
+        }).bind(this).then(function (migrations) {
+          this.migrations = migrations;
+        });
+      });      
+      it('should return 1 migration', function () {
+        expect(this.migrations).to.have.length(1);
+      });
+      it('should be the last migration', function() {
+        expect(this.migrations[0].file).to.equal('3-migration.js');
+      });
+    });
+  });
+
   describe('when passing the `to` option', function () {
     beforeEach(function () {
       return this.umzug.up({


### PR DESCRIPTION
In my workflow, developing a desktop native app using Electron, I need the functionality were migrations are executed from a specific migration and onwards.

The case is simple, my app gets installed on new machines. Something new comes up for the next version and so I create `migration-1`.

When I will release the next version which includes the `migration-1` script, i want this migration to run on all clients that have the app already installed and not run on new installations of the new version which incorporate the migration part in the codebase / db schema already.

so would you accept a `from` option for the up() method?