### PR TITLE
Extend official support of Sequelize and Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 dist: trusty
 
 language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ language: node_js
 
 node_js:
   - "0.10"
+  - "0.12"
+  - "iojs-v1"
+  - "iojs-v2"
+  - "iojs-v3"
+  - "4"
+  - "5"
 
 before_script:
   - npm install sequelize@$(echo $SEQUELIZE)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_script:
   - npm install sequelize@$(echo $SEQUELIZE)
 
 env:
-  - SEQUELIZE=1.7.10
-  - SEQUELIZE=2.0.0-rc8
-  - SEQUELIZE=2.0.0
+  - SEQUELIZE=^1.0.0
+  - SEQUELIZE=^2.0.0
+  - SEQUELIZE=^3.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,15 @@ before_script:
   - npm install sequelize@$(echo $SEQUELIZE)
 
 env:
-  - SEQUELIZE=^1.0.0
-  - SEQUELIZE=^2.0.0
-  - SEQUELIZE=^3.0.0
+  - SEQUELIZE=^1.0.0 CXX=g++-4.8
+  - SEQUELIZE=^2.0.0 CXX=g++-4.8
+  - SEQUELIZE=^3.0.0 CXX=g++-4.8
+
+sudo: false
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
-script:
-  - "npm test"
-
-notifications:
-  irc:
-    - "chat.freenode.net#sequelizejs"
+sudo: false
+dist: trusty
 
 language: node_js
 
@@ -16,19 +12,17 @@ node_js:
   - "4"
   - "5"
 
+env:
+  - SEQUELIZE=^1.0.0
+  - SEQUELIZE=^2.0.0
+  - SEQUELIZE=^3.0.0
+
 before_script:
   - npm install sequelize@$(echo $SEQUELIZE)
 
-env:
-  - SEQUELIZE=^1.0.0 CXX=g++-4.8
-  - SEQUELIZE=^2.0.0 CXX=g++-4.8
-  - SEQUELIZE=^3.0.0 CXX=g++-4.8
+script:
+  - "npm test"
 
-sudo: false
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
+notifications:
+  irc:
+    - "chat.freenode.net#sequelizejs"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Using the [`json` storage](lib/storages/json.js) will create a JSON file which w
 ```
 
 ### Sequelize
-Using the [`sequelize` storage](lib/storages/sequelize.js) will create a table in your database called `SequelizeMeta` containing an entry for each executed migration. You will have to pass a configured instance of Sequelize or an existing Sequelize model. Optionally you can specify the model name, table name, or column name.
+Using the [`sequelize` storage](lib/storages/sequelize.js) will create a table in your database called `SequelizeMeta` containing an entry for each executed migration. You will have to pass a configured instance of Sequelize or an existing Sequelize model. Optionally you can specify the model name, table name, or column name. All major Sequelize versions are supported.
 
 #### Options
 


### PR DESCRIPTION
Extend official support (a.k.a. by CI testing) to cover all major Sequelize versions on multiple Node.js versions.

Now supported Sequelize versions are ^1.0.0, ^2.0.0, and ^3.0.0 and Node.js versions are 0.10, 0.12, 1 (io.js), 2 (io.js), 3 (io.js), 4 and 5.

See #73. /cc @sdepold