### PR TITLE
Make Umzug an EventEmitter, add four events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ Using the [`sequelize` storage](lib/storages/sequelize.js) will create a table i
 }
 ```
 
+#### Events
+
+Umzug is an EventEmitter. Each of the following events will be called with `name, migration` as arguments. Events are a convenient place
+to implement application-specific logic that must run around each migration:
+
+* *migrating* - A migration is about to be executed.
+* *migrated* - A migration has successfully been executed.
+* *reverting* - A migration is about to be reverted.
+* *reverted* - A migration has successfully been reverted.
+
 ### None
 If want to run migrations without storing them anywhere, you can use the [`none` storage](lib/storages/none.js).
 

--- a/index.js
+++ b/index.js
@@ -6,8 +6,11 @@ var fs        = require('fs');
 var Migration = require('./lib/migration');
 var path      = require('path');
 var redefine  = require('redefine');
+var EventEmitter = require('events');
 
 var Umzug = module.exports = redefine.Class({
+  extend: EventEmitter.EventEmitter,
+
   constructor: function (options) {
     this.options = _.assign({
       storage:        'json',
@@ -29,6 +32,8 @@ var Umzug = module.exports = redefine.Class({
     }, this.options.migrations);
 
     this.storage = this._initStorage();
+
+    EventEmitter.EventEmitter.call(this);
   },
 
   execute: function (options) {
@@ -69,8 +74,10 @@ var Umzug = module.exports = redefine.Class({
 
                 if (options.method === 'up') {
                   self.log("== " + name + ": migrating =======");
+                  self.emit('migrating', name, migration);
                 } else {
                   self.log("== " + name + ": reverting =======");
+                  self.emit('reverting', name, migration);
                 }
 
                 startTime = new Date();
@@ -89,8 +96,10 @@ var Umzug = module.exports = redefine.Class({
               var duration = ((new Date() - startTime) / 1000).toFixed(3);
               if (options.method === 'up') {
                 self.log("== " + name + ": migrated (" + duration +  "s)\n");
+                self.emit('migrated', name, migration);
               } else {
                 self.log("== " + name + ": reverted (" + duration +  "s)\n");
+                self.emit('reverted', name, migration);
               }
             });
         });

--- a/test/index/execute.test.js
+++ b/test/index/execute.test.js
@@ -27,6 +27,10 @@ describe('execute', function () {
             method:     method
           });
         }.bind(this);
+        ['migrating', 'migrated', 'reverting', 'reverted'].forEach(function(event) {
+          var spy = this[event + 'EventSpy'] = sinon.spy();
+          this.umzug.on(event, spy);
+        }, this);
       });
   });
 
@@ -44,6 +48,8 @@ describe('execute', function () {
         expect(this.logSpy.callCount).to.equal(2);
         expect(this.logSpy.getCall(0).args[0]).to.equal('== 123-migration: migrating =======');
         expect(this.logSpy.getCall(1).args[0]).to.match(/== 123-migration: migrated \(0\.0\d\ds\)/);
+        expect(this.migratingEventSpy.calledWith('123-migration')).to.equal(true);
+        expect(this.migratedEventSpy.calledWith('123-migration')).to.equal(true);
       });
   });
 
@@ -56,6 +62,8 @@ describe('execute', function () {
         expect(this.logSpy.callCount).to.equal(2);
         expect(this.logSpy.getCall(0).args[0]).to.equal('== 123-migration: reverting =======');
         expect(this.logSpy.getCall(1).args[0]).to.match(/== 123-migration: reverted \(0\.0\d\ds\)/);
+        expect(this.revertingEventSpy.calledWith('123-migration')).to.equal(true);
+        expect(this.revertedEventSpy.calledWith('123-migration')).to.equal(true);
       });
   });
 


### PR DESCRIPTION
The attached PR adds EventEmitter functionality to Umzug. Unit tests and documentation for four useful events are included.

Rationale: My application has some logging and consistency-checking requirements for each migration that go beyond what can be conveniently done via the `logging` option. This leads to a lot of boilerplate code in migrations, to the point where almost 50% of a typical migration is this boilerplate. This makes migrations a bit ugly to read, and it's more lifting for new team members.

Using the event emitter pattern could let us eliminate this boilerplate by giving us more programmatic/event-driven insight into the individual migrations Umzug was running.