### PR TITLE
Support ES6 module defaults with Babel6

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -97,6 +97,9 @@ module.exports = redefine.Class(/** @lends Migration.prototype */{
    */
   _exec: function (method, args) {
     var migration  = this.migration();
+    if (migration.default) {
+      migration = migration.default;
+    }
     var fun        = migration[method] || Bluebird.resolve;
     var wrappedFun = this.options.migrations.wrap(fun);
 

--- a/test/index/execute.test.js
+++ b/test/index/execute.test.js
@@ -182,6 +182,40 @@ describe('coffee-script support', function () {
   });
 });
 
+describe('ES6 module support', function () {
+  beforeEach(function () {
+    helper.clearTmp();
+    require('fs').writeFileSync(__dirname + '/../tmp/123-ES6-module-migration.js', [
+      '\'use strict\'',
+      '',
+      'module.exports = {',
+      ' default: {',
+      '    up: function () {},',
+      '    down: function () {}',
+      '  }',
+      '}'
+      ].join('\n')
+    );
+  });
+
+  it('runs the migration', function () {
+    var umzug = new Umzug({
+      migrations: {
+        path:    __dirname + '/../tmp/',
+        pattern: /\.js/
+      },
+      storageOptions: {
+        path: __dirname + '/../tmp/umzug.json'
+      }
+    });
+
+    return umzug.execute({
+      migrations: ['123-ES6-module-migration'],
+      method:     'up'
+    });
+  });
+});
+
 describe('upName / downName', function () {
   beforeEach(function () {
     helper.clearTmp();


### PR DESCRIPTION
In my setup, I had my migrations as the default export of an ES6 module
that was transpiled with Babel and it didn't work. This fixes it.

See http://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default.

I wasn't sure how to test this without introducing babel, so I faked it a bit.
Let me know if you have better ideas.

Take this as another vote for https://github.com/sequelize/umzug/issues/79.
`umzug` really should leave module resolution to the end user...that way it
doesn't have to support everything under the sun (coffeescript, babel, typescript).
