### PR TITLE
Added option timestamps to sequelize storage

### DIFF
--- a/lib/storages/sequelize.js
+++ b/lib/storages/sequelize.js
@@ -40,6 +40,9 @@ module.exports = redefine.Class(/** @lends SequelizeStorage.prototype*/ {
    * @param {String} [options.storageOptions.columnType=Sequelize.STRING] - type
    * of the column. For utf8mb4 charsets under InnoDB, you may need to set
    * this <= 190.
+   * @param {Boolean} [options.storageOptions.timestamps=false] - option to add
+   * timestamps to model table
+   *
    * @constructs SequelizeStorage
    */
   constructor: function (options) {
@@ -48,7 +51,8 @@ module.exports = redefine.Class(/** @lends SequelizeStorage.prototype*/ {
       // note 'sequelize' or 'model' is required
       modelName: 'SequelizeMeta',
       // note 'tableName' (optional) also supported
-      columnName: 'name'
+      columnName: 'name',
+      timestamps: false
     }, this.options.storageOptions || {});
 
     if (!this.options.storageOptions.model && !this.options.storageOptions.sequelize) {
@@ -81,7 +85,7 @@ module.exports = redefine.Class(/** @lends SequelizeStorage.prototype*/ {
           {
             tableName:  this.options.storageOptions.tableName,
             schema: this.options.storageOptions.schema,
-            timestamps: false,
+            timestamps: this.options.storageOptions.timestamps,
             charset: 'utf8',
             collate: 'utf8_unicode_ci'
           }

--- a/test/storages/sequelize.test.js
+++ b/test/storages/sequelize.test.js
@@ -107,6 +107,22 @@ describe('sequelize', function () {
         });
     });
 
+    it('accepts a "timestamps" option', function () {
+      var storage = new Storage({
+        storageOptions: {
+          sequelize: this.sequelize,
+          timestamps: true
+        }
+      });
+      return storage.options.storageOptions.model.sync()
+        .then(function (model) {
+          return model.describe();
+        })
+        .then(function(description) {
+          expect(description).to.only.have.keys(['name','createdAt','updatedAt']);
+        });
+    });
+
     it('accepts a "columnType" option', function () {
       var storage = new Storage({
         storageOptions: {
@@ -204,6 +220,25 @@ describe('sequelize', function () {
           expect(migrations[0].customColumnName).to.be('asd.js');
         });
     });
+
+    it('writes the migration to the database with timestamps', function () {
+      var storage = new Storage({
+        storageOptions: {
+          sequelize: this.sequelize,
+          timestamps: true
+        }
+      });
+
+      return storage.logMigration('asd.js')
+        .then(function() {
+          return storage.options.storageOptions.model.findAll();
+        })
+        .then(function(migrations) {
+          expect(migrations.length).to.be(1);
+          expect(migrations[0].name).to.be('asd.js');
+          expect(new Date() - migrations[0].createdAt).to.be.lessThan(100);
+        });
+    });
   }); //end describe('logMigration', function() {
 
   describe('unlogMigration', function () {
@@ -289,6 +324,32 @@ describe('sequelize', function () {
         });
     });
 
+    it('deletes the migration from the database with timestamps', function () {
+      var storage = new Storage({
+        storageOptions: {
+          sequelize: this.sequelize,
+          timestamps: true
+        }
+      });
+
+      return storage.logMigration('asd.js')
+        .then(function() {
+          return storage.options.storageOptions.model.findAll();
+        })
+        .then(function(migrations) {
+          expect(migrations.length).to.be(1);
+        })
+        .then(function() {
+          return storage.unlogMigration('asd.js');
+        })
+        .then(function() {
+          return storage.options.storageOptions.model.findAll();
+        })
+        .then(function(migrations) {
+          expect(migrations).to.be.empty();
+        });
+    });
+
   });
 
   describe('executed', function () {
@@ -348,6 +409,23 @@ describe('sequelize', function () {
         storageOptions: {
           sequelize: this.sequelize,
           columnName: 'customColumnName'
+        }
+      });
+
+      return storage.logMigration('asd.js')
+        .then(function() {
+          return storage.executed();
+        })
+        .then(function(migrations) {
+          expect(migrations).to.be.eql(['asd.js']);
+        });
+    });
+
+    it('returns executed migrations with timestamps', function () {
+      var storage = new Storage({
+        storageOptions: {
+          sequelize: this.sequelize,
+          timestamps: true
         }
       });
 


### PR DESCRIPTION
This PR adds the possibility to call the sequelize storage with timestamps set to true. This gives the migration table the `createdAt´ and ´updatedAt´ attributes.

This option defaults to false so there is no break in the logic.