### PR TITLE
fix(pattern-validation-error): Throw error when a file is not matching the pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -416,6 +416,9 @@ var Umzug = module.exports = redefine.Class(/** @lends Umzug.prototype */ {
       .promisify(fs.readdir)(this.options.migrations.path)
       .bind(this)
       .filter(function (file) {
+        if(!this.options.migrations.pattern.test(file)) {
+          throw new Error('File: ' + file + ' does not match pattern: ' + this.options.migrations.pattern);
+        }
         return this.options.migrations.pattern.test(file);
       })
       .map(function (file) {


### PR DESCRIPTION
It's a trivial logging addition to disclose when a migration task file pattern is not matching the default one. It seems to be a common gotcha that would save a lot of time to Umzug adopters because invalid file patterns are silently ignored. 