### PR TITLE
Reject migration if umzug can't find the migration method

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -97,7 +97,8 @@ module.exports = redefine.Class(/** @lends Migration.prototype */{
    */
   _exec: function (method, args) {
     var migration  = this.migration();
-    var fun        = migration[method] || Bluebird.resolve;
+    var fun        = migration[method];
+    if (!fun) return Bluebird.reject('Could not find migration method: ' + method);
     var wrappedFun = this.options.migrations.wrap(fun);
 
     return wrappedFun.apply(migration, args);

--- a/test/index/execute.test.js
+++ b/test/index/execute.test.js
@@ -108,6 +108,26 @@ describe('execute', function () {
       expect(this.upStub.getCall(0).args).to.eql([1, 2, 3]);
     });
   });
+
+  describe('when the migration does not contain a migration method', function () {
+    beforeEach(function () {
+      this.oldup = this.migration.up;
+      delete this.migration.up;
+    });
+
+    it('rejects the promise', function () {
+      return this.migrate('up').bind(this).then(function () {
+        return Bluebird.reject('We should not end up here...');
+      }, function (err) {
+        expect(err).to.equal('Could not find migration method: up');
+      });
+    });
+
+    afterEach(function () {
+      this.migration.up = this.oldup;
+      delete this.oldup;
+    });
+  });
 });
 
 describe('migrations.wrap', function () {


### PR DESCRIPTION
Rationale: you will never have a no-op migration. Currently, if the up or down methods can't be found when running a migration, Umzug replaces the method body with Promise.resolve() and tells you that the migration was run correctly. (It wasn't.)

This PR rejects the migration if you try to run it but that function doesn't exist.