### PR TITLE
Optimize Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: false
-dist: trusty
 
 language: node_js
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 dist: trusty
 
 language: node_js


### PR DESCRIPTION
I compared following Travis configs:

- Trusty, sudo
- Trusty, no sudo
- Precise, no sudo

Precise, no sudo was winner as it can run up to 5 builds at the same time (original was 3). Individual build times are few seconds longer but the total build time drops ~30%.