### PR TITLE
ES6 classes + minor maintenance tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Future
+### Added
+- Warn about ignored files in migrations directory [#108](https://github.com/sequelize/umzug/pull/108)
 
 ## v1.12.0 - 2017-04-21
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 sequelize
+Copyright (c) 2014-2017 Sequelize contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -315,4 +315,24 @@ It is possible to configure *umzug* instance via passing an object to the constr
 ```
 
 ## License
-MIT
+The MIT License (MIT)
+
+Copyright (c) 2014-2017 Sequelize contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "umzug",
   "version": "1.12.0",
   "description": "Framework agnostic migration tool for Node.JS",
+  "keywords": [
+    "migrate",
+    "migration",
+    "migrations",
+    "sequelize"
+  ],
   "main": "lib/index.js",
   "dependencies": {
     "bluebird": "^3.4.1",
@@ -29,16 +35,25 @@
   },
   "scripts": {
     "build": "babel src -d lib",
-    "test": "gulp test"
+    "test": "gulp"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/sequelize/umzug.git"
   },
-  "author": "",
+  "author": "Sascha Depold <sascha@depold.com>",
+  "contributors": [
+    {
+      "name": "Jukka Hyytiälä",
+      "email": "hyytiala.jukka@gmail.com"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/sequelize/umzug/issues"
   },
-  "homepage": "https://github.com/sequelize/umzug"
+  "homepage": "https://github.com/sequelize/umzug",
+  "engines": {
+    "node": ">=4.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "bluebird": "^3.4.1",
     "lodash": "^4.17.0",
     "moment": "^2.16.0",
-    "redefine": "^0.2.0",
     "resolve": "^1.0.0"
   },
   "devDependencies": {
@@ -35,7 +34,7 @@
   },
   "scripts": {
     "build": "babel src -d lib",
-    "test": "gulp"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "babel src -d lib",
-    "test": "gulp"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",

--- a/src/migration.js
+++ b/src/migration.js
@@ -3,12 +3,11 @@
 var _path    = require('path');
 var Bluebird = require('bluebird');
 var helper   = require('./helper');
-var redefine = require('redefine');
 
 /**
  * @class Migration
  */
-module.exports = redefine.Class(/** @lends Migration.prototype */{
+module.exports = class Migration {
   /**
    * Wrapper function for migration methods.
    *
@@ -31,11 +30,11 @@ module.exports = redefine.Class(/** @lends Migration.prototype */{
    * migration methods.
    * @constructs Migration
    */
-  constructor: function(path, options) {
+  constructor(path, options) {
     this.path    = _path.resolve(path);
     this.file    = _path.basename(this.path);
     this.options = options;
-  },
+  }
 
   /**
    * Tries to require migration module. CoffeeScript support requires
@@ -43,7 +42,7 @@ module.exports = redefine.Class(/** @lends Migration.prototype */{
    *
    * @returns {Object} Required migration module
    */
-  migration: function () {
+  migration() {
     if (this.path.match(/\.coffee$/)) {
       // 1.7.x compiler registration
       helper.resolve('coffee-script/register') ||
@@ -58,34 +57,34 @@ module.exports = redefine.Class(/** @lends Migration.prototype */{
     }
 
     return require(this.path);
-  },
+  }
 
   /**
    * Executes method `up` of migration.
    *
    * @returns {*|Promise}
    */
-  up: function () {
+  up() {
     return this._exec(this.options.upName, [].slice.apply(arguments));
-  },
+  }
 
   /**
    * Executes method `down` of migration.
    *
    * @returns {*|Promise}
    */
-  down: function () {
+  down() {
     return this._exec(this.options.downName, [].slice.apply(arguments));
-  },
+  }
 
   /**
    * Check if migration file name is starting with needle.
    * @param {String} needle - The beginning of the file name.
    * @returns {boolean}
    */
-  testFileName: function (needle) {
+  testFileName(needle) {
     return this.file.indexOf(needle) === 0;
-  },
+  }
 
   /**
    * Executes a given method of migration with given arguments.
@@ -95,7 +94,7 @@ module.exports = redefine.Class(/** @lends Migration.prototype */{
    * @returns {*|Promise}
    * @private
    */
-  _exec: function (method, args) {
+  _exec(method, args) {
     var migration  = this.migration();
     var fun        = migration[method];
     if (!fun) return Bluebird.reject('Could not find migration method: ' + method);
@@ -103,4 +102,4 @@ module.exports = redefine.Class(/** @lends Migration.prototype */{
 
     return wrappedFun.apply(migration, args);
   }
-});
+}

--- a/src/storages/json.js
+++ b/src/storages/json.js
@@ -4,12 +4,11 @@ var _         = require('lodash');
 var Bluebird  = require('bluebird');
 var fs        = require('fs');
 var path      = require('path');
-var redefine  = require('redefine');
 
 /**
  * @class JSONStorage
  */
-module.exports = redefine.Class(/** @lends JSONStorage.prototype */ {
+module.exports = class JSONStorage {
   /**
    * Constructs JSON file storage.
    *
@@ -20,13 +19,13 @@ module.exports = redefine.Class(/** @lends JSONStorage.prototype */ {
    * cwd.
    * @constructs JSONStorage
    */
-  constructor: function (options) {
+  constructor(options) {
     this.options = options || {};
 
     this.options.storageOptions = _.assign({
       path: path.resolve(process.cwd(), 'umzug.json')
     }, this.options.storageOptions || {});
-  },
+  }
 
   /**
    * Logs migration to be considered as executed.
@@ -34,7 +33,7 @@ module.exports = redefine.Class(/** @lends JSONStorage.prototype */ {
    * @param {String} migrationName - Name of the migration to be logged.
    * @returns {Promise}
    */
-  logMigration: function (migrationName) {
+  logMigration(migrationName) {
     var filePath  = this.options.storageOptions.path;
     var readfile  = Bluebird.promisify(fs.readFile);
     var writefile = Bluebird.promisify(fs.writeFile);
@@ -46,7 +45,7 @@ module.exports = redefine.Class(/** @lends JSONStorage.prototype */ {
         content.push(migrationName);
         return writefile(filePath, JSON.stringify(content, null, '  '));
       });
-  },
+  }
 
   /**
    * Unlogs migration to be considered as pending.
@@ -54,7 +53,7 @@ module.exports = redefine.Class(/** @lends JSONStorage.prototype */ {
    * @param {String} migrationName - Name of the migration to be unlogged.
    * @returns {Promise}
    */
-  unlogMigration: function (migrationName) {
+  unlogMigration(migrationName) {
     var filePath  = this.options.storageOptions.path;
     var readfile  = Bluebird.promisify(fs.readFile);
     var writefile = Bluebird.promisify(fs.writeFile);
@@ -66,14 +65,14 @@ module.exports = redefine.Class(/** @lends JSONStorage.prototype */ {
         content = _.without(content, migrationName);
         return writefile(filePath, JSON.stringify(content, null, '  '));
       });
-  },
+  }
 
   /**
    * Gets list of executed migrations.
    *
    * @returns {Promise.<String[]>}
    */
-  executed: function () {
+  executed() {
     var filePath = this.options.storageOptions.path;
     var readfile = Bluebird.promisify(fs.readFile);
 
@@ -83,4 +82,4 @@ module.exports = redefine.Class(/** @lends JSONStorage.prototype */ {
         return JSON.parse(content);
       });
   }
-});
+}

--- a/src/storages/none.js
+++ b/src/storages/none.js
@@ -1,19 +1,18 @@
 'use strict';
 
 var Bluebird  = require('bluebird');
-var redefine  = require('redefine');
 
 /**
  * @class NoneStorage
  */
-module.exports = redefine.Class(/** @lends NoneStorage.prototype */ {
+module.exports = class NoneStorage {
   /**
    * Constructs none storage.
    *
    * @param {Object} [options]
    * @constructs NoneStorage
    */
-  constructor: function (options) {},
+  constructor(options) {}
 
   /**
    * Does nothing.
@@ -21,9 +20,9 @@ module.exports = redefine.Class(/** @lends NoneStorage.prototype */ {
    * @param {String} migrationName - Name of migration to be logged.
    * @returns {Promise}
    */
-  logMigration: function (migrationName) {
+  logMigration(migrationName) {
     return Bluebird.resolve();
-  },
+  }
 
   /**
    * Does nothing.
@@ -31,16 +30,16 @@ module.exports = redefine.Class(/** @lends NoneStorage.prototype */ {
    * @param {String} migrationName - Name of migration to unlog.
    * @returns {Promise}
    */
-  unlogMigration: function (migrationName) {
+  unlogMigration(migrationName) {
     return Bluebird.resolve();
-  },
+  }
 
   /**
    * Does nothing.
    *
    * @returns {Promise.<String[]>}
    */
-  executed: function () {
+  executed() {
     return Bluebird.resolve([]);
   }
-});
+}

--- a/src/storages/sequelize.js
+++ b/src/storages/sequelize.js
@@ -1,12 +1,11 @@
 'use strict';
 
 var _         = require('lodash');
-var redefine  = require('redefine');
 
 /**
  * @class SequelizeStorage
  */
-module.exports = redefine.Class(/** @lends SequelizeStorage.prototype*/ {
+module.exports = class SequelizeStorage {
   /**
    * Constructs Sequelize based storage.
    *
@@ -45,7 +44,7 @@ module.exports = redefine.Class(/** @lends SequelizeStorage.prototype*/ {
    *
    * @constructs SequelizeStorage
    */
-  constructor: function (options) {
+  constructor(options) {
     this.options = options || {};
     this.options.storageOptions = _.assign({
       // note 'sequelize' or 'model' is required
@@ -92,7 +91,7 @@ module.exports = redefine.Class(/** @lends SequelizeStorage.prototype*/ {
         );
       }
     }
-  },
+  }
 
   /**
    * Logs migration to be considered as executed.
@@ -100,7 +99,7 @@ module.exports = redefine.Class(/** @lends SequelizeStorage.prototype*/ {
    * @param {String} migrationName - Name of the migration to be logged.
    * @returns {Promise}
    */
-  logMigration: function (migrationName) {
+  logMigration(migrationName) {
     var self = this;
 
     return this._model()
@@ -110,7 +109,7 @@ module.exports = redefine.Class(/** @lends SequelizeStorage.prototype*/ {
         migration[self.options.storageOptions.columnName] = migrationName;
         return Model.create(migration);
       });
-  },
+  }
 
   /**
    * Unlogs migration to be considered as pending.
@@ -118,7 +117,7 @@ module.exports = redefine.Class(/** @lends SequelizeStorage.prototype*/ {
    * @param {String} migrationName - Name of the migration to be unlogged.
    * @returns {Promise}
    */
-  unlogMigration: function (migrationName) {
+  unlogMigration(migrationName) {
     var self             = this;
     var sequelize        = this.options.storageOptions.sequelize;
     var sequelizeVersion = !!sequelize.modelManager ? 2 : 1;
@@ -136,14 +135,14 @@ module.exports = redefine.Class(/** @lends SequelizeStorage.prototype*/ {
 
         return Model.destroy(where);
       });
-  },
+  }
 
   /**
    * Gets list of executed migrations.
    *
    * @returns {Promise.<String[]>}
    */
-  executed: function () {
+  executed() {
     var self = this;
 
     return this._model()
@@ -156,7 +155,7 @@ module.exports = redefine.Class(/** @lends SequelizeStorage.prototype*/ {
           return migration[self.options.storageOptions.columnName];
         });
       });
-  },
+  }
 
   /**
    * Gets Sequelize model used as a storage.
@@ -164,7 +163,7 @@ module.exports = redefine.Class(/** @lends SequelizeStorage.prototype*/ {
    * @returns {Sequelize.Model}
    * @private
    */
-  _model: function () {
+  _model() {
     return this.options.storageOptions.model;
   }
-});
+}

--- a/test/helper.js
+++ b/test/helper.js
@@ -9,7 +9,7 @@ var helper = module.exports = {
     var files = fs.readdirSync(__dirname + '/tmp');
 
     files.forEach(function (file) {
-      if (file.match(/\.(js|json|sqlite)$/)) {
+      if (file.match(/\.(js|json|sqlite|coffee)$/)) {
         fs.unlinkSync(__dirname + '/tmp/' + file);
       }
     });

--- a/test/index/constructor.test.js
+++ b/test/index/constructor.test.js
@@ -3,8 +3,13 @@
 var expect    = require('expect.js');
 var Umzug     = require('../../lib/index');
 var sinon     = require('sinon');
+var helper    = require('../helper');
 
 describe('constructor', function () {
+  beforeEach(function() {
+    helper.clearTmp();
+  });
+
   it('exposes some methods', function () {
     var umzug = new Umzug();
 

--- a/test/index/down.test.js
+++ b/test/index/down.test.js
@@ -7,6 +7,7 @@ var Umzug     = require('../../lib/index');
 
 describe('down', function () {
   beforeEach(function () {
+    helper.clearTmp();
     return helper
       .prepareMigrations(3)
       .bind(this)

--- a/test/index/execute.test.js
+++ b/test/index/execute.test.js
@@ -14,8 +14,8 @@ describe('execute', function () {
       .bind(this)
       .then(function () {
         this.migration = require('../tmp/123-migration.js');
-        this.upStub    = sinon.stub(this.migration, 'up', Bluebird.resolve);
-        this.downStub  = sinon.stub(this.migration, 'down', Bluebird.resolve);
+        this.upStub    = sinon.stub(this.migration, 'up').callsFake(Bluebird.resolve);
+        this.downStub  = sinon.stub(this.migration, 'down').callsFake(Bluebird.resolve);
         this.logSpy    = sinon.spy();
         this.umzug     = new Umzug({
           migrations:     { path: __dirname + '/../tmp/' },
@@ -218,8 +218,8 @@ describe('upName / downName', function () {
         ].join('\n')
     );
     this.migration = require('../tmp/123-custom-up-down-names-migration.js');
-    this.upStub    = sinon.stub(this.migration, 'myUp', Bluebird.resolve);
-    this.downStub  = sinon.stub(this.migration, 'myDown', Bluebird.resolve);
+    this.upStub    = sinon.stub(this.migration, 'myUp').callsFake(Bluebird.resolve);
+    this.downStub  = sinon.stub(this.migration, 'myDown').callsFake(Bluebird.resolve);
     this.umzug     = new Umzug({
       migrations:     { path: __dirname + '/../tmp/' },
       storageOptions: { path: __dirname + '/../tmp/umzug.json' },

--- a/test/index/execute.test.js
+++ b/test/index/execute.test.js
@@ -8,6 +8,7 @@ var sinon     = require('sinon');
 
 describe('execute', function () {
   beforeEach(function () {
+    helper.clearTmp();
     return helper
       .prepareMigrations(1, { names: ['123-migration'] })
       .bind(this)

--- a/test/index/executed.test.js
+++ b/test/index/executed.test.js
@@ -6,6 +6,7 @@ var Umzug     = require('../../lib/index');
 
 describe('executed', function () {
   beforeEach(function () {
+    helper.clearTmp();
     return helper
       .prepareMigrations(3)
       .bind(this)

--- a/test/index/pending.test.js
+++ b/test/index/pending.test.js
@@ -7,6 +7,7 @@ var Umzug     = require('../../lib/index');
 
 describe('pending', function () {
   beforeEach(function () {
+    helper.clearTmp();
     return helper
       .prepareMigrations(3)
       .bind(this)

--- a/test/index/up.test.js
+++ b/test/index/up.test.js
@@ -8,6 +8,7 @@ var Umzug     = require('../../lib/index');
 
 describe('up', function () {
   beforeEach(function () {
+    helper.clearTmp();
     return helper
       .prepareMigrations(3)
       .bind(this)

--- a/test/storages/json.test.js
+++ b/test/storages/json.test.js
@@ -8,6 +8,10 @@ var path      = require('path');
 var Storage   = require('../../lib/storages/json');
 
 describe('JSON', function () {
+  beforeEach(function() {
+    helper.clearTmp();
+  });
+
   describe('constructor', function () {
     it('stores options', function () {
       var storage = new Storage();

--- a/test/storages/none.test.js
+++ b/test/storages/none.test.js
@@ -5,6 +5,10 @@ var helper    = require('../helper');
 var Storage   = require('../../lib/storages/none');
 
 describe('none', function () {
+  beforeEach(function() {
+    helper.clearTmp();
+  });
+
   describe('constructor', function () {
     it('stores no options', function () {
       var storage = new Storage();


### PR DESCRIPTION
A list of unrelated maintenance tasks:
- Use ES6 classes :sparkles:
- Update package data
- Make tests more stable
- Resolve deprecation warnings in tests

This contains small API changes (redefine classes => ES6 classes) but it should not be considered as a breaking change.