### PR TITLE
Feature: Support ES6 modules and default exports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,9 @@
     }]
   ],
   "plugins": [
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "syntax-dynamic-import",
+    "dynamic-import-node",
+    "transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,17 @@
   ],
   "main": "lib/index.js",
   "dependencies": {
+    "babel-runtime": "^6.23.0",
     "bluebird": "^3.4.1",
     "lodash": "^4.17.0",
     "resolve": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babel-plugin-dynamic-import-node": "^1.0.1",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.4.0",
     "babel-register": "^6.24.1",
     "coffee-script": "^1.8.0",

--- a/src/migration.js
+++ b/src/migration.js
@@ -40,7 +40,7 @@ module.exports = class Migration {
    *
    * @returns {Promise.<Object>} Required migration module
    */
-  async migration() {
+  migration() {
     if (this.path.match(/\.coffee$/)) {
       // 1.7.x compiler registration
       helper.resolve('coffee-script/register') ||
@@ -62,7 +62,7 @@ module.exports = class Migration {
    *
    * @returns {Promise}
    */
-  async up() {
+  up() {
     return this._exec(this.options.upName, [].slice.apply(arguments));
   }
 
@@ -71,7 +71,7 @@ module.exports = class Migration {
    *
    * @returns {Promise}
    */
-  async down() {
+  down() {
     return this._exec(this.options.downName, [].slice.apply(arguments));
   }
 
@@ -98,9 +98,10 @@ module.exports = class Migration {
     if (migration.default) {
       fun = migration.default[method] || migration[method];
     }
-    if (!fun) return Bluebird.reject('Could not find migration method: ' + method);
+    // TODO throw new Error(...)
+    if (!fun) throw 'Could not find migration method: ' + method;
     const wrappedFun = this.options.migrations.wrap(fun);
 
-    return wrappedFun.apply(migration, args);
+    return await wrappedFun.apply(migration, args);
   }
 }

--- a/test/Umzug/execute.test.js
+++ b/test/Umzug/execute.test.js
@@ -203,6 +203,58 @@ describe('coffee-script support', function () {
   });
 });
 
+describe('ES6 module support', function () {
+  beforeEach(function () {
+    helper.clearTmp();
+  });
+
+  it('executes exported method', function () {
+    require('fs').writeFileSync(__dirname + '/../tmp/123-es6-named-migration.js', `
+      export async function up() {}
+      export async function down() {}
+    `);
+
+    var umzug = new Umzug({
+      migrations: {
+        path:    __dirname + '/../tmp/',
+        pattern: /\.js$/
+      },
+      storageOptions: {
+        path: __dirname + '/../tmp/umzug.json'
+      }
+    });
+
+    return umzug.execute({
+      migrations: ['123-es6-named-migration'],
+      method:     'up'
+    });
+  });
+
+  it('executes default exported method', function () {
+    require('fs').writeFileSync(__dirname + '/../tmp/123-es6-default-migration.js', `
+      export default {
+        async up() {},
+        async down() {}
+      }
+    `);
+
+    var umzug = new Umzug({
+      migrations: {
+        path:    __dirname + '/../tmp/',
+        pattern: /\.js$/
+      },
+      storageOptions: {
+        path: __dirname + '/../tmp/umzug.json'
+      }
+    });
+
+    return umzug.execute({
+      migrations: ['123-es6-default-migration'],
+      method:     'up'
+    });
+  });
+});
+
 describe('upName / downName', function () {
   beforeEach(function () {
     helper.clearTmp();

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,9 +276,21 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-dynamic-import-node@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.0.1.tgz#2da67305da3cc34ad81b4490620cbd40e05f8c2c"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-template "^6.23.0"
+    babel-types "^6.23.0"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
@@ -489,6 +501,12 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "0.9.11"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
@@ -550,14 +568,14 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.24.1:
+babel-template@^6.23.0, babel-template@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
   dependencies:
@@ -581,7 +599,7 @@ babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.19.0, babel-types@^6.24.1:
+babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:


### PR DESCRIPTION
Add support to ES6 modules. It actually becomes useful only when Node.js gets
support for ES6 modules in the future.

This implementation supports both default exported object and direct named
exports.

```js
// case 1: default exported object
export default {
  up() {},
  down() {},
}

// case 2: named exports
export function up() {}
export function down() {}
```

# BREAKING CHANGES
- ~`Migration.migration()`, `Migration.up()`, and `Migration.down()` are now async.
  They are not in public API but potentially used from external apps.~
- `Migration.migration()` returns now `Promise<Object>` not `Object`. It is not in public API but potentially used from external apps.
- `Migration.up()` and `Migration.down()` returns now `Promise` not `*|Promise`.