### PR TITLE
throw error if a migration method doesn't return a thenable

### DIFF
--- a/src/migration.js
+++ b/src/migration.js
@@ -108,7 +108,11 @@ module.exports = class Migration {
     }
     if (!fun) throw new Error('Could not find migration method: ' + method);
     const wrappedFun = this.options.migrations.wrap(fun);
+    const result = wrappedFun.apply(migration, args);
+    if (!result || typeof result.then !== 'function') {
+      throw new Error(`Migration ${this.file} (or wrapper) didn't return a promise`);
+    }
 
-    await wrappedFun.apply(migration, args);
+    await result;
   }
 };

--- a/test/helper.js
+++ b/test/helper.js
@@ -21,7 +21,7 @@ const helper = module.exports = {
     }
   },
 
-  generateDummyMigration: function (name, subDirectories) {
+  generateDummyMigration: function (name, subDirectories, options = {}) {
     let path = join(__dirname, '/tmp/');
     if (subDirectories) {
       if (!_.isArray(subDirectories)) {
@@ -40,8 +40,8 @@ const helper = module.exports = {
         '\'use strict\';',
         '',
         'module.exports = {',
-        '  up: function () {},',
-        '  down: function () {}',
+        `  up: function () { return ${options.returnUndefined ? 'undefined' : 'Promise.resolve()'}; },`,
+        `  down: function () { return ${options.returnUndefined ? 'undefined' : 'Promise.resolve()'}; }`,
         '};',
       ].join('\n')
     );
@@ -58,6 +58,7 @@ const helper = module.exports = {
       // example 3: ['foo',['foo','bar2']] ==> generates /foo and /foo/bar2
       ...options || {},
     };
+    const {returnUndefined} = options;
 
     return new Promise((resolve) => {
       let names = options.names;
@@ -68,7 +69,7 @@ const helper = module.exports = {
       _.times(count, (i) => {
         num++;
         names.push(options.names[i] || (num + '-migration'));
-        helper.generateDummyMigration(names[i], options.directories[i]);
+        helper.generateDummyMigration(names[i], options.directories[i], {returnUndefined});
       });
 
       resolve(names);


### PR DESCRIPTION
Although the README says that

> In order to allow asynchronicity, tasks have return a Promise object which provides a then method

In actuality, tasks that don't return a Promise succeed and can cause intermittent failures if something else is writing to the database at the same time (since umzug can't wait for the operations in the task to finish).  I just discovered yesterday that I wasn't returning Promises from my migration tasks (because I hadn't RTFM...), and now I know why I had seen inconsistent migration behavior in the past.

This PR at least throws an error whenever a task doesn't return a thenable object, so that devs will find out immediately if they make this mistake.