### PR TITLE
support passing an array of Migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ It is possible to configure *umzug* instance via passing an object to the constr
   // The name of the negative method in migrations.
   downName: 'down',
 
+  // (advanced) you can pass an array of Migration instances instead of the options below
   migrations: {
     // The params that gets passed to the migrations.
     // Might be an array or a synchronous function which returns an array.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umzug",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Framework agnostic migration tool for Node.JS",
   "keywords": [
     "migrate",

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -6,6 +6,7 @@ import typescript from 'typescript';
 import coffeescript from 'coffee-script';
 import helper from '../helper';
 import Umzug from '../../src';
+import Migration from '../../src/migration';
 
 describe('custom resolver', () => {
   beforeEach(function () {
@@ -52,6 +53,36 @@ describe('custom resolver', () => {
     this.customResolver = undefined;
 
     await this.umzug().up();
+
+    await this.verifyTables();
+  });
+
+  it('an array of migrations created manually can be passed in', async function () {
+    const umzug = new Umzug({
+      migrations: [
+        new Migration(require.resolve('./javascript/1.users'), {
+          upName: 'up',
+          downName: 'down',
+          migrations: {
+            wrap: fn => () => fn(this.sequelize.getQueryInterface(), this.sequelize.constructor),
+          },
+        }),
+        new Migration(require.resolve('./javascript/2.things'), {
+          upName: 'up',
+          downName: 'down',
+          migrations: {
+            wrap: fn => () => fn(this.sequelize.getQueryInterface(), this.sequelize.constructor),
+          },
+        }),
+      ],
+      storage: 'sequelize',
+      storageOptions: {
+        path: this.storagePath,
+        sequelize: this.sequelize,
+      },
+    });
+
+    await umzug.up();
 
     await this.verifyTables();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3140,7 +3140,7 @@ sprintf-js@~1.0.2:
 
 sqlite3@^3.1.13:
   version "3.1.13"
-  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-3.1.13.tgz#d990a05627392768de6278bafd1a31fdfe907dd9"
+  resolved "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.13.tgz#d990a05627392768de6278bafd1a31fdfe907dd9"
   dependencies:
     nan "~2.7.0"
     node-pre-gyp "~0.6.38"


### PR DESCRIPTION
I want to rock the boat a bit: the current method of giving sequelize a directory and glob pattern to find migrations isn't very flexible, and neither are other options people have suggested (providing multiple directories, passing in an array of files).

I need to provide a way for plugins in my app to inject their own migrations that live in a different directory from the app core, and possible even use a mix of languages (coffee, typescript, etc).