### PR TITLE
feat: support passing array of migration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,8 @@ It is possible to configure *umzug* instance by passing an object to the constru
   // The name of the negative method in migrations.
   downName: 'down',
 
-  // (advanced) you can pass an array of Migration instances instead of the options below
+  // This can be an object or an array of objects. Pass an array if you want to 
+  // load from different paths, or have a different resolver for different file types
   migrations: {
     // The params that gets passed to the migrations.
     // Might be an array or a synchronous function which returns an array.
@@ -352,7 +353,11 @@ It is possible to configure *umzug* instance by passing an object to the constru
     customResolver: function (sqlPath)  {
         return { up: () => sequelize.query(require('fs').readFileSync(sqlPath, 'utf8')) }
     }
-  }
+  },
+  
+  // (advanced) an array of pre-configured Migration instances. 
+  // If this is set, `options.migrations` is ignored.
+  migrationInstances: [new Migration('custom-migration.js'), {...}]
 }
 ```
 

--- a/src/migration.js
+++ b/src/migration.js
@@ -22,10 +22,8 @@ module.exports = class Migration {
    * module.
    * @param {String} options.downName - Name of the method `down` in migration
    * module.
-   * @param {Object} options.migrations
-   * @param {Migration~wrap} options.migrations.wrap - Wrapper function for
-   * migration methods.
-   * @param {Migration~customResolver} [options.migrations.customResolver] - A
+   * @param {function} options.wrap - Wrapper function for migration methods.
+   * @param {function} options.customResolver - A
    * function that specifies how to get a migration object from a path. This
    * should return an object of the form { up: Function, down: Function }.
    * Without this defined, a regular javascript import will be performed.
@@ -46,8 +44,8 @@ module.exports = class Migration {
    * @returns {Promise.<Object>} Required migration module
    */
   migration () {
-    if (typeof this.options.migrations.customResolver === 'function') {
-      return this.options.migrations.customResolver(this.path);
+    if (typeof this.options.customResolver === 'function') {
+      return this.options.customResolver(this.path);
     }
     if (this.path.match(/\.coffee$/)) {
       // 2.x compiler registration
@@ -110,7 +108,7 @@ module.exports = class Migration {
       fun = migration.default[method] || migration[method];
     }
     if (!fun) throw new Error('Could not find migration method: ' + method);
-    const wrappedFun = this.options.migrations.wrap(fun);
+    const wrappedFun = this.options.wrap(fun);
 
     await wrappedFun.apply(migration, args);
   }

--- a/test/Umzug/constructor.test.js
+++ b/test/Umzug/constructor.test.js
@@ -55,4 +55,11 @@ describe('constructor', function () {
     umzug.log();
     expect(spy.called).to.be.true;
   });
+
+  it('converts migration options object to array', () => {
+    const umzug = new Umzug({ migrations: { traverseDirectories: true } });
+    expect(umzug.options.migrations).to.be.an.array;
+    expect(umzug.options.migrations).to.have.length(1);
+    expect(umzug.options.migrations[0].traverseDirectories).to.be.true;
+  });
 });

--- a/test/Umzug/execute.test.js
+++ b/test/Umzug/execute.test.js
@@ -93,7 +93,7 @@ describe('execute', function () {
   });
 
   it('calls the migration with the specified params', function () {
-    this.umzug.options.migrations.params = [1, 2, 3];
+    this.umzug.options.migrations[0].params = [1, 2, 3];
 
     return this.migrate('up').then(() => {
       expect(this.upStub.getCall(0).args).to.eql([1, 2, 3]);
@@ -101,7 +101,7 @@ describe('execute', function () {
   });
 
   it('calls the migration with the result of the passed function', function () {
-    this.umzug.options.migrations.params = () => {
+    this.umzug.options.migrations[0].params = () => {
       return [1, 2, 3];
     };
 

--- a/test/Umzug/findMigrations.test.js
+++ b/test/Umzug/findMigrations.test.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import helper from '../helper';
+import Umzug from '../../src/index';
+import { join } from 'path';
+
+describe('_findMigrations', function () {
+  beforeEach(function () {
+    helper.clearTmp();
+    return helper.prepareMigrations(4, {
+      directories: [['one'], ['one'], ['two', '1'], ['two', '2']],
+    });
+  });
+
+  it('loads files with each config', async function () {
+    const umzug = new Umzug({
+      migrations: [
+        { path: join(__dirname, '..', 'tmp', 'one') },
+        {
+          path: join(__dirname, '..', 'tmp', 'two'),
+          pattern: /3-migration/,
+          traverseDirectories: true,
+        },
+      ],
+    });
+    const migrations = await umzug._findMigrations();
+    expect(migrations).to.have.length(3);
+    expect(migrations.map(m => m.file)).to.eql([
+      '1-migration.js',
+      '2-migration.js',
+      '3-migration.js',
+    ]);
+  });
+});

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -57,22 +57,18 @@ describe('custom resolver', () => {
     await this.verifyTables();
   });
 
-  it('an array of migrations created manually can be passed in', async function () {
+  it('an array of migrations instances created manually can be passed in', async function () {
     const umzug = new Umzug({
       migrations: [
         new Migration(require.resolve('./javascript/1.users'), {
           upName: 'up',
           downName: 'down',
-          migrations: {
-            wrap: fn => () => fn(this.sequelize.getQueryInterface(), this.sequelize.constructor),
-          },
+          wrap: fn => () => fn(this.sequelize.getQueryInterface(), this.sequelize.constructor),
         }),
         new Migration(require.resolve('./javascript/2.things'), {
           upName: 'up',
           downName: 'down',
-          migrations: {
-            wrap: fn => () => fn(this.sequelize.getQueryInterface(), this.sequelize.constructor),
-          },
+          wrap: fn => () => fn(this.sequelize.getQueryInterface(), this.sequelize.constructor),
         }),
       ],
       storage: 'sequelize',


### PR DESCRIPTION
`options.migrations` can now be an array of options objects:
- allows users to load data from multiple different folders (fixes #151 and supersedes #106)
- has use cases like specifying a resolver only for a certain file type
- still supports passing an array of `Migration`s in `options.migrations` (#164) but this is deprecated in favour of `options.migrationInstances`.
- doesn't change any public API but does change the shape of the options passed to `Migration`

Wasn't sure which file to put the new test in so created a new file.

Didn't know if I should update the Changelog or the version number.