### PR TITLE
Exclude patterns to avoid unnecessary logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,9 @@ It is possible to configure *umzug* instance by passing an object to the constru
     // The pattern that determines whether or not a file is a migration.
     pattern: /^\d+[\w-]+\.js$/,
 
+    // These patterns are excluded from the migrations path, otherwise a log will show up.
+    exclude: [/\.map$/, /\.gitkeep$/],
+
     // A function that receives and returns the to be executed function.
     // This can be used to modify the function.
     wrap: function (fun) { return fun; },

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,7 @@ module.exports = class Umzug extends EventEmitter {
 
     if (!Array.isArray(this.options.migrations)) {
       this.options.migrations = {
+        exclude: [],
         params: [],
         path: path.resolve(process.cwd(), 'migrations'),
         pattern: /^\d+[\w-]+\.js$/,
@@ -445,7 +446,14 @@ module.exports = class Umzug extends EventEmitter {
         if (this.options.migrations.pattern.test(file)) {
           return new Migration(filePath, this.options);
         }
-        this.log('File: ' + file + ' does not match pattern: ' + this.options.migrations.pattern);
+
+        const isExcluded = this.options.migrations.exclude.reduce(
+          (isExcluded, excludePattern) => isExcluded || excludePattern.test(file), false
+        );
+        if (!isExcluded) {
+          this.log('File: ' + file + ' does not match pattern: ' + this.options.migrations.pattern);
+        }
+
         return file;
       })
       .reduce((a, b) => a.concat(b), []) // flatten the result to an array

--- a/test/Umzug/execute.test.js
+++ b/test/Umzug/execute.test.js
@@ -63,6 +63,22 @@ describe('execute', () => {
       });
   });
 
+  it('ignores file patters found on the migration path', function () {
+    this.umzug.options.migrations.exclude = [/\.gitkeep$/];
+
+    return this
+      .migrate('up')
+      .then(() => {
+        expect(this.upStub.callCount).to.equal(1);
+        expect(this.downStub.callCount).to.equal(0);
+        expect(this.logSpy.callCount).to.equal(2);
+        expect(this.logSpy.getCall(0).args[0]).to.equal('== 123-migration: migrating =======');
+        expect(this.logSpy.getCall(1).args[0]).to.match(/== 123-migration: migrated \(0\.0\d\ds\)/);
+        expect(this.migratingEventSpy.calledWith('123-migration')).to.equal(true);
+        expect(this.migratedEventSpy.calledWith('123-migration')).to.equal(true);
+      });
+  });
+
   it('runs the up method of the migration', function () {
     return this
       .migrate('up')


### PR DESCRIPTION
Addresses #182 #177

This PR attempts to add a migration option called `exclude` which is an array of patterns. If any file that is not a migration file and compiles any of these patterns, it will be ignored, otherwise the usual log will show up.