### PR TITLE
don't log non-migration files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -445,7 +445,6 @@ module.exports = class Umzug extends EventEmitter {
         if (this.options.migrations.pattern.test(file)) {
           return new Migration(filePath, this.options);
         }
-        this.log('File: ' + file + ' does not match pattern: ' + this.options.migrations.pattern);
         return file;
       })
       .reduce((a, b) => a.concat(b), []) // flatten the result to an array

--- a/test/Umzug/execute.test.js
+++ b/test/Umzug/execute.test.js
@@ -69,7 +69,7 @@ describe('execute', () => {
       .then(() => {
         expect(this.upStub.callCount).to.equal(1);
         expect(this.downStub.callCount).to.equal(0);
-        expect(this.logSpy.callCount).to.equal(3);
+        expect(this.logSpy.callCount).to.equal(2);
         expect(this.logSpy.getCall(0).args[0]).to.equal('== 123-migration: migrating =======');
         expect(this.logSpy.getCall(1).args[0]).to.match(/== 123-migration: migrated \(0\.0\d\ds\)/);
         expect(this.migratingEventSpy.calledWith('123-migration')).to.equal(true);
@@ -83,7 +83,7 @@ describe('execute', () => {
       .then(() => {
         expect(this.upStub.callCount).to.equal(0);
         expect(this.downStub.callCount).to.equal(1);
-        expect(this.logSpy.callCount).to.equal(3);
+        expect(this.logSpy.callCount).to.equal(2);
         expect(this.logSpy.getCall(0).args[0]).to.equal('== 123-migration: reverting =======');
         expect(this.logSpy.getCall(1).args[0]).to.match(/== 123-migration: reverted \(0\.0\d\ds\)/);
         expect(this.revertingEventSpy.calledWith('123-migration')).to.equal(true);

--- a/test/Umzug/execute.test.js
+++ b/test/Umzug/execute.test.js
@@ -70,9 +70,8 @@ describe('execute', () => {
         expect(this.upStub.callCount).to.equal(1);
         expect(this.downStub.callCount).to.equal(0);
         expect(this.logSpy.callCount).to.equal(3);
-        expect(this.logSpy.getCall(0).args[0]).to.match(/File: \.gitkeep does not match pattern: .+/);
-        expect(this.logSpy.getCall(1).args[0]).to.equal('== 123-migration: migrating =======');
-        expect(this.logSpy.getCall(2).args[0]).to.match(/== 123-migration: migrated \(0\.0\d\ds\)/);
+        expect(this.logSpy.getCall(0).args[0]).to.equal('== 123-migration: migrating =======');
+        expect(this.logSpy.getCall(1).args[0]).to.match(/== 123-migration: migrated \(0\.0\d\ds\)/);
         expect(this.migratingEventSpy.calledWith('123-migration')).to.equal(true);
         expect(this.migratedEventSpy.calledWith('123-migration')).to.equal(true);
       });
@@ -85,9 +84,8 @@ describe('execute', () => {
         expect(this.upStub.callCount).to.equal(0);
         expect(this.downStub.callCount).to.equal(1);
         expect(this.logSpy.callCount).to.equal(3);
-        expect(this.logSpy.getCall(0).args[0]).to.match(/File: \.gitkeep does not match pattern: .+/);
-        expect(this.logSpy.getCall(1).args[0]).to.equal('== 123-migration: reverting =======');
-        expect(this.logSpy.getCall(2).args[0]).to.match(/== 123-migration: reverted \(0\.0\d\ds\)/);
+        expect(this.logSpy.getCall(0).args[0]).to.equal('== 123-migration: reverting =======');
+        expect(this.logSpy.getCall(1).args[0]).to.match(/== 123-migration: reverted \(0\.0\d\ds\)/);
         expect(this.revertingEventSpy.calledWith('123-migration')).to.equal(true);
         expect(this.revertedEventSpy.calledWith('123-migration')).to.equal(true);
       });


### PR DESCRIPTION
@PascalPflaum very minor thing, but it's been bugging me for a while. There's not much value in logging when a filename isn't matched by `pattern` since that's the whole reason `pattern` exists. It can end up a little noisy on stdout.