### PR TITLE
Support symlinked migrations directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,10 +339,13 @@ It is possible to configure *umzug* instance by passing an object to the constru
     // The pattern that determines whether or not a file is a migration.
     pattern: /^\d+[\w-]+\.js$/,
 
+    // Search for migrations matching the pattern in the subdirectories
+    traverseDirectories: false,
+
     // A function that receives and returns the to be executed function.
     // This can be used to modify the function.
     wrap: function (fun) { return fun; },
-    
+
     // A function that maps a file path to a migration object in the form
     // { up: Function, down: Function }. The default for this is to require(...)
     // the file as javascript, but you can use this to transpile TypeScript,

--- a/src/index.js
+++ b/src/index.js
@@ -437,7 +437,7 @@ module.exports = class Umzug extends EventEmitter {
       .map(function (file) {
         const filePath = path.resolve(migrationPath, file);
         if (this.options.migrations.traverseDirectories) {
-          if (fs.lstatSync(filePath).isDirectory()) {
+          if (fs.statSync(filePath).isDirectory()) {
             return this._findMigrations(filePath)
               .then((migrations) => migrations);
           }

--- a/test/Umzug/down.test.js
+++ b/test/Umzug/down.test.js
@@ -348,3 +348,20 @@ describe('down-directories', () => {
 
   downTestSuite();
 });
+
+describe('down-directories with symbolicRef', () => {
+  beforeEach(function () {
+    helper.clearTmp();
+    return helper
+      .prepareMigrations(3, { directories: [['1', '2'], ['1', '2'], ['1', '3', '4', '5']], usesSymbolicRef: true })
+      .then((migrationNames) => {
+        this.migrationNames = migrationNames;
+        this.umzug = new Umzug({
+          migrations: { path: join(__dirname, '/../tmp/1'), traverseDirectories: true },
+          storageOptions: { path: join(__dirname, '/../tmp/umzug.json') },
+        });
+      });
+  });
+
+  downTestSuite();
+});

--- a/test/Umzug/executed.test.js
+++ b/test/Umzug/executed.test.js
@@ -121,3 +121,20 @@ describe('executed-directories', () => {
 
   executedTestSuite();
 });
+
+describe('executed-directories with symbolicRef', () => {
+  beforeEach(function () {
+    helper.clearTmp();
+    return helper
+      .prepareMigrations(3, { directories: [['1', '2'], ['1', '2'], ['1', '3', '4', '5']], usesSymbolicRef: true })
+      .then((migrationNames) => {
+        this.migrationNames = migrationNames;
+        this.umzug = new Umzug({
+          migrations: { path: join(__dirname, '/../tmp/1'), traverseDirectories: true },
+          storageOptions: { path: join(__dirname, '/../tmp/umzug.json') },
+        });
+      });
+  });
+
+  executedTestSuite();
+});

--- a/test/Umzug/pending.test.js
+++ b/test/Umzug/pending.test.js
@@ -113,3 +113,20 @@ describe('pending-directories', () => {
 
   pendingTestSuite();
 });
+
+describe('pending-directories with symbolicRef', () => {
+  beforeEach(function () {
+    helper.clearTmp();
+    return helper
+      .prepareMigrations(3, { directories: [['1', '2'], ['1', '2'], ['1', '3', '4', '5']], usesSymbolicRef: true })
+      .then((migrationNames) => {
+        this.migrationNames = migrationNames;
+        this.umzug = new Umzug({
+          migrations: { path: join(__dirname, '/../tmp/1'), traverseDirectories: true },
+          storageOptions: { path: join(__dirname, '/../tmp/umzug.json') },
+        });
+      });
+  });
+
+  pendingTestSuite();
+});

--- a/test/Umzug/up.test.js
+++ b/test/Umzug/up.test.js
@@ -304,3 +304,20 @@ describe('up-directories', () => {
 
   upTestuite();
 });
+
+describe('up-directories with symbolicRef', () => {
+  beforeEach(function () {
+    helper.clearTmp();
+    return helper
+      .prepareMigrations(3, { directories: [['1', '2'], ['1', '2'], ['1', '3', '4', '5']], usesSymbolicRef: true })
+      .then((migrationNames) => {
+        this.migrationNames = migrationNames;
+        this.umzug = new Umzug({
+          migrations: { path: join(__dirname, '/../tmp/1'), traverseDirectories: true },
+          storageOptions: { path: join(__dirname, '/../tmp/umzug.json') },
+        });
+      });
+  });
+
+  upTestuite();
+});

--- a/test/helper.js
+++ b/test/helper.js
@@ -24,7 +24,7 @@ const helper = module.exports = {
   },
 
   generateDummyMigration: function (name, subDirectories, options = {}) {
-    const randomName = () => Math.random().toString(36).substring(2, 15)
+    const randomName = () => Math.random().toString(36).substring(2, 15);
     let path = join(__dirname, '/tmp/');
     let migrationsPath = path;
     if (subDirectories) {


### PR DESCRIPTION
@jukkah I don't know how useful this would be, considering the outlined roadmap. 
However, I was in the same situation as #33 and from the thread, I observed it was now possible to `traverseDirectories` following #80 
This PR basically builds on that idea.

The idea here is:
An app that gets it's migrations from
```
/plugins
  | A/migrations
  | B/migrations
  | C/migrations
```
can easily just symlink the plugins into the main app migrations folder like:
```sh
ln -s plugins/A app/migrations/A
...
```
And configure sequelize to traverse directories for migrations.

*Why change from `lstatSync` to `statSync`?*
https://github.com/nodejs/node/issues/25342 and https://nodejs.org/api/fs.html#fs_fs_lstat_path_options_callback
Basically, 
```js
fs.lstatSync(filePath).isDirectory() => false
fs.lstatSync(filePath). isSymbolicLink() => true
```
returns the information about the link itself: which is `is the link a directory?` => No
While
```js
fs.statSync(filePath).isDirectory() => true
fs.statSync(filePath).isSymbolicLink() => false
```
gives information about the directory it's pointing at.