### PR TITLE
Rename `build` script to `prepare`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 before_script:
   - npm i sequelize@$(echo $SEQUELIZE)
-  - npm run build
+  - npm run prepare
 
 script:
   - npm run lint

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "uuid": "^3.3.2"
   },
   "scripts": {
-    "build": "babel src --out-dir lib",
     "lint": "eslint src test",
+    "prepare": "babel src --out-dir lib",
     "test": "mocha -r babel-register --check-leaks test/index.js"
   },
   "repository": {


### PR DESCRIPTION
Enables Umzug to be installed from a Git repository. [From the npm documentation](https://docs.npmjs.com/cli/install):

> If the package being installed contains a `prepare` script, its `dependencies` and `devDependencies` will be installed, and the prepare script will be run, before the package is packaged and installed.