### PR TITLE
feat: add format function

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ const umzug = new Umzug({
         return { up: () => sequelize.query(require('fs').readFileSync(sqlPath, 'utf8')) };
     }
 
-    // A function that receives the file name of the migration and returns the name of the 
+    // A function that receives the file path of the migration and returns the name of the 
     // migration. This can be used to remove file extensions for example.
-    nameFormatter: function (fileName) {
+    nameFormatter: function (filePath) {
         return path.parse(fileName).name;
     }
   }

--- a/README.md
+++ b/README.md
@@ -349,8 +349,14 @@ It is possible to configure *umzug* instance by passing an object to the constru
     // read raw sql etc.
     // See https://github.com/sequelize/umzug/tree/master/test/fixtures
     // for examples.
-    customResolver: function (sqlPath)  {
-        return { up: () => sequelize.query(require('fs').readFileSync(sqlPath, 'utf8')) }
+    customResolver: function (sqlPath) {
+        return { up: () => sequelize.query(require('fs').readFileSync(sqlPath, 'utf8')) };
+    }
+
+    // A function that receives the file name of the migration and returns the name of the 
+    // migration. This can be used to remove file extensions for example.
+    nameFormatter: function (fileName) {
+        return path.parse(fileName).name;
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ const umzug = new Umzug({
     // A function that receives the file path of the migration and returns the name of the 
     // migration. This can be used to remove file extensions for example.
     nameFormatter: function (filePath) {
-        return path.parse(fileName).name;
+        return path.parse(filePath).name;
     }
   }
 })

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,9 @@ module.exports = class Umzug extends EventEmitter {
    * function that specifies how to get a migration object from a path. This
    * should return an object of the form { up: Function, down: Function }.
    * Without this defined, a regular javascript import will be performed.
+   * @param {Migration~format} [options.migrations.format] - A function that
+   * receives the file name of the migration and returns the name of the 
+   * migration. This can be used to remove file extensions for example.
    * @constructs Umzug
    */
   constructor (options = {}) {
@@ -69,6 +72,7 @@ module.exports = class Umzug extends EventEmitter {
         pattern: /^\d+[\w-]+\.js$/,
         traverseDirectories: false,
         wrap: fun => fun,
+        format: undefined,
         ...this.options.migrations,
       };
     }
@@ -154,7 +158,7 @@ module.exports = class Umzug extends EventEmitter {
    * @returns {Promise.<Migration>}
    */
   executed () {
-    return Bluebird.resolve(this.storage.executed()).bind(this).map((file) => new Migration(file));
+    return Bluebird.resolve(this.storage.executed()).bind(this).map((file) => new Migration(file, this.options));
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ module.exports = class Umzug extends EventEmitter {
    * should return an object of the form { up: Function, down: Function }.
    * Without this defined, a regular javascript import will be performed.
    * @param {Migration~nameFormatter} [options.migrations.nameFormatter] - A
-   * function that receives the file name of the migration and returns the name
+   * function that receives the file path of the migration and returns the name
    * of the migration. This can be used to remove file extensions for example.
    * @constructs Umzug
    */

--- a/src/index.js
+++ b/src/index.js
@@ -44,9 +44,9 @@ module.exports = class Umzug extends EventEmitter {
    * function that specifies how to get a migration object from a path. This
    * should return an object of the form { up: Function, down: Function }.
    * Without this defined, a regular javascript import will be performed.
-   * @param {Migration~format} [options.migrations.format] - A function that
-   * receives the file name of the migration and returns the name of the 
-   * migration. This can be used to remove file extensions for example.
+   * @param {Migration~nameFormatter} [options.migrations.nameFormatter] - A
+   * function that receives the file name of the migration and returns the name
+   * of the migration. This can be used to remove file extensions for example.
    * @constructs Umzug
    */
   constructor (options = {}) {
@@ -72,7 +72,7 @@ module.exports = class Umzug extends EventEmitter {
         pattern: /^\d+[\w-]+\.js$/,
         traverseDirectories: false,
         wrap: fun => fun,
-        format: undefined,
+        nameFormatter: undefined,
         ...this.options.migrations,
       };
     }

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,6 @@ module.exports = class Umzug extends EventEmitter {
         pattern: /^\d+[\w-]+\.js$/,
         traverseDirectories: false,
         wrap: fun => fun,
-        nameFormatter: undefined,
         ...this.options.migrations,
       };
     }

--- a/src/migration.js
+++ b/src/migration.js
@@ -38,7 +38,7 @@ module.exports = class Migration {
     this.path = _path.resolve(path);
     this.options = options;
 
-    if (options && typeof options.migrations.format === 'function') {
+    if (options && options.migrations && typeof options.migrations.format === 'function') {
         this.file = options.migrations.format(this.path);
     } else {
         this.file = _path.basename(path);

--- a/src/migration.js
+++ b/src/migration.js
@@ -44,7 +44,7 @@ module.exports = class Migration {
         throw new Error(`Unexpected migration formatter result for '${this.path}': expected string, got ${typeof this.file}`);
       }
     } else {
-        this.file = _path.basename(path);
+      this.file = _path.basename(path);
     }
   }
 

--- a/src/migration.js
+++ b/src/migration.js
@@ -29,12 +29,20 @@ module.exports = class Migration {
    * function that specifies how to get a migration object from a path. This
    * should return an object of the form { up: Function, down: Function }.
    * Without this defined, a regular javascript import will be performed.
+   * @param {Migration~format} [options.migrations.format] - A function that
+   * receives the file name of the migration and returns the name of the 
+   * migration. This can be used to remove file extensions for example.
    * @constructs Migration
    */
   constructor (path, options) {
     this.path = _path.resolve(path);
-    this.file = _path.basename(this.path);
     this.options = options;
+
+    if (options && typeof options.migrations.format === 'function') {
+        this.file = options.migrations.format(this.path);
+    } else {
+        this.file = _path.basename(path);
+    }
   }
 
   /**

--- a/src/migration.js
+++ b/src/migration.js
@@ -29,17 +29,17 @@ module.exports = class Migration {
    * function that specifies how to get a migration object from a path. This
    * should return an object of the form { up: Function, down: Function }.
    * Without this defined, a regular javascript import will be performed.
-   * @param {Migration~format} [options.migrations.format] - A function that
-   * receives the file name of the migration and returns the name of the 
-   * migration. This can be used to remove file extensions for example.
+   * @param {Migration~nameFormatter} [options.migrations.nameFormatter] - A
+   * function that receives the file name of the migration and returns the name
+   * of the migration. This can be used to remove file extensions for example.
    * @constructs Migration
    */
   constructor (path, options) {
     this.path = _path.resolve(path);
     this.options = options;
 
-    if (options && options.migrations && typeof options.migrations.format === 'function') {
-      this.file = options.migrations.format(this.path);
+    if (options && options.migrations && typeof options.migrations.nameFormatter === 'function') {
+      this.file = options.migrations.nameFormatter(this.path);
       if (typeof this.file !== 'string') {
         throw new Error(`Unexpected migration formatter result for '${this.path}': expected string, got ${typeof this.file}`);
       }

--- a/src/migration.js
+++ b/src/migration.js
@@ -39,7 +39,10 @@ module.exports = class Migration {
     this.options = options;
 
     if (options && options.migrations && typeof options.migrations.format === 'function') {
-        this.file = options.migrations.format(this.path);
+      this.file = options.migrations.format(this.path);
+      if (typeof this.file !== 'string') {
+        throw new Error(`Unexpected migration formatter result for '${this.path}': expected string, got ${typeof this.file}`);
+      }
     } else {
         this.file = _path.basename(path);
     }

--- a/src/migration.js
+++ b/src/migration.js
@@ -30,7 +30,7 @@ module.exports = class Migration {
    * should return an object of the form { up: Function, down: Function }.
    * Without this defined, a regular javascript import will be performed.
    * @param {Migration~nameFormatter} [options.migrations.nameFormatter] - A
-   * function that receives the file name of the migration and returns the name
+   * function that receives the file path of the migration and returns the name
    * of the migration. This can be used to remove file extensions for example.
    * @constructs Migration
    */

--- a/src/migration.js
+++ b/src/migration.js
@@ -103,7 +103,8 @@ module.exports = class Migration {
    * @returns {boolean}
    */
   testFileName (needle) {
-    return this.file.indexOf(needle) === 0;
+    const formattedNeedle = this.options.nameFormatter(needle);
+    return this.file.indexOf(formattedNeedle) === 0;
   }
 
   /**

--- a/src/migration.js
+++ b/src/migration.js
@@ -34,17 +34,19 @@ module.exports = class Migration {
    * of the migration. This can be used to remove file extensions for example.
    * @constructs Migration
    */
-  constructor (path, options) {
+  constructor (path, options = {}) {
     this.path = _path.resolve(path);
-    this.options = options;
+    this.options = {
+      ...options,
+      migrations: {
+        nameFormatter: (path) => _path.basename(path),
+        ...options.migrations,
+      },
+    };
 
-    if (options && options.migrations && typeof options.migrations.nameFormatter === 'function') {
-      this.file = options.migrations.nameFormatter(this.path);
-      if (typeof this.file !== 'string') {
-        throw new Error(`Unexpected migration formatter result for '${this.path}': expected string, got ${typeof this.file}`);
-      }
-    } else {
-      this.file = _path.basename(path);
+    this.file = this.options.migrations.nameFormatter(this.path);
+    if (typeof this.file !== 'string') {
+      throw new Error(`Unexpected migration formatter result for '${this.path}': expected string, got ${typeof this.file}`);
     }
   }
 
@@ -103,7 +105,7 @@ module.exports = class Migration {
    * @returns {boolean}
    */
   testFileName (needle) {
-    const formattedNeedle = this.options.nameFormatter(needle);
+    const formattedNeedle = this.options.migrations.nameFormatter(needle);
     return this.file.indexOf(formattedNeedle) === 0;
   }
 

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve, dirname, join, basename } from 'path';
+import { resolve, dirname, join, parse } from 'path';
 import { expect } from 'chai';
 import Sequelize from 'sequelize';
 import typescript from 'typescript';
@@ -32,7 +32,7 @@ describe('custom resolver', () => {
           ],
           pattern: this.pattern,
           customResolver: this.customResolver,
-          nameFormatter: (path) => basename(path).replace(/\.[^/.]+$/, ''), // Remove file extension
+          nameFormatter: (path) => parse(path).name,
         },
         storage: 'sequelize',
         storageOptions: {
@@ -73,7 +73,7 @@ describe('custom resolver', () => {
           downName: 'down',
           migrations: {
             wrap: fn => () => fn(this.sequelize.getQueryInterface(), this.sequelize.constructor),
-            nameFormatter: (path) => basename(path).replace(/\.[^/.]+$/, ''), // Remove file extension
+            nameFormatter: (path) => parse(path).name,
           },
         }),
         new Migration(require.resolve('./javascript/2.things'), {
@@ -81,7 +81,7 @@ describe('custom resolver', () => {
           downName: 'down',
           migrations: {
             wrap: fn => () => fn(this.sequelize.getQueryInterface(), this.sequelize.constructor),
-            nameFormatter: (path) => basename(path).replace(/\.[^/.]+$/, ''), // Remove file extension
+            nameFormatter: (path) => parse(path).name,
           },
         }),
       ],


### PR DESCRIPTION
Sometimes you want to modify the name of the migration (e.g. in my case I would like to remove the file suffix because it changes depending on whether I run the Typescript or compiled version). This PR introduces a format function in the options that takes care of it.