### PR TITLE
Configure babel to not rely on babel-runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,10 @@
     "transform-object-rest-spread",
     "syntax-dynamic-import",
     "dynamic-import-node",
-    "transform-runtime"
+    ["transform-runtime", {
+      "polyfill": false,
+      "regenerator": true,
+      "helpers": false
+    }]
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -909,6 +909,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1223,7 +1224,8 @@
     "core-js": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3866,7 +3868,8 @@
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   ],
   "main": "lib/index.js",
   "dependencies": {
-    "babel-runtime": "^6.23.0",
     "bluebird": "^3.5.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Yields a 123 bytes increase in the transpiled files, but avoids 8 MB of dependencies 😌