### PR TITLE
chore: editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
this stops github rendering tabs as eight (!) spaces