### PR TITLE
chore: use localeCompare for string comparison

### DIFF
--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -41,24 +41,14 @@ export class Umzug extends EventEmitter {
 			};
 		}
 
-		const defaultSorting = (a, b) => {
-			if (a > b) {
-				return 1;
-			}
-
-			if (a < b) {
-				return -1;
-			}
-
-			return 0;
-		};
+		const defaultSorting = (a: string, b: string) => a.localeCompare(b);
 
 		this.options = {
 			storage: options.storage ?? 'json',
 			storageOptions: options.storageOptions ?? {},
 			logging: options.logging ?? false,
 			migrationSorting: options.migrationSorting ?? defaultSorting,
-			migrations
+			migrations,
 		};
 
 		this.storage = Umzug.resolveStorageOption(this.options.storage, this.options.storageOptions);

--- a/test/test.ts
+++ b/test/test.ts
@@ -102,17 +102,7 @@ test('migration sort', async () => {
 				},
 			},
 		]),
-		migrationSorting: (a, b) => {
-			if (a > b) {
-				return -1;
-			}
-
-			if (a < b) {
-				return 1;
-			}
-
-			return 0;
-		},
+		migrationSorting: (a, b) => b.localeCompare(a),
 	});
 	const names = (migrations: Migration[]) => migrations.map(m => m.file);
 


### PR DESCRIPTION
Very small PR to use the built-in [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) method rather than our own implementation. Test coverage highlighted that we hadn't fully tested our implementation.

FYI @rockers7414 @papb 