### PR TITLE
test: events

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,19 +28,7 @@ module.exports = {
   globals: { __dirname: true, process: true },
   rules: {
     'codegen/codegen': 'warn',
-    'prettier/prettier': [
-      'warn',
-      {
-        singleQuote: true,
-        semi: true,
-        arrowParens: 'avoid',
-        trailingComma: 'es5',
-        bracketSpacing: true,
-        endOfLine: 'auto',
-        printWidth: 120,
-        useTabs: true,
-      },
-    ],
+    'prettier/prettier': ['error',require('./.prettierrc')],
 
     'prefer-arrow-callback': 'error',
     'prefer-const': 'error',

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  singleQuote: true,
+  semi: true,
+  arrowParens: 'avoid',
+  trailingComma: 'es5',
+  bracketSpacing: true,
+  endOfLine: 'auto',
+  printWidth: 120,
+  useTabs: true,
+}

--- a/test/fixtures/javascript/1.users.js
+++ b/test/fixtures/javascript/1.users.js
@@ -1,7 +1,6 @@
-const { readFileSync } = require('fs');
-const { resolve } = require('path');
-
-const sql = readFileSync(resolve(__dirname, '../sql/1.users.sql'), 'utf8');
-const up = ({ sequelize }) => sequelize.query(sql);
-
-module.exports = { up };
+exports.up = ({ sequelize }) => sequelize.query(`
+  CREATE TABLE user (
+    id INTEGER PRIMARY KEY,
+    name VARCHAR
+  );
+`);

--- a/test/fixtures/javascript/2.things.js
+++ b/test/fixtures/javascript/2.things.js
@@ -1,7 +1,7 @@
-const { readFileSync } = require('fs');
-const { resolve } = require('path');
-
-const sql = readFileSync(resolve(__dirname, '../sql/2.things.sql'), 'utf8');
-const up = ({ sequelize }) => sequelize.query(sql);
-
-module.exports = { up };
+exports.up = ({ sequelize }) => sequelize.query(`
+  CREATE TABLE thing (
+    id INTEGER PRIMARY KEY,
+    name VARCHAR,
+    ownerId INTEGER REFERENCES user(id)
+  );
+`);

--- a/test/test.ts
+++ b/test/test.ts
@@ -166,7 +166,7 @@ test('events', async () => {
 		]),
 	});
 
-	// `.addListener` and `.on` are aliases -us both to make sure they're wired up properly
+	// `.addListener` and `.on` are aliases - use both to make sure they're wired up properly
 	umzug.addListener('migrating', spy('migrating'));
 	umzug.on('migrated', spy('migrated'));
 	umzug.addListener('reverting', spy('reverting'));

--- a/test/test.ts
+++ b/test/test.ts
@@ -156,7 +156,7 @@ test('migration sort', async () => {
 test('events', async () => {
 	const mock = jest.fn();
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-	const spy = (label: string) => (...args) => mock([label, ...args]);
+	const spy = (label: string) => (...args) => mock(label, ...args);
 
 	const umzug = new Umzug({
 		storage: memoryStorage(),
@@ -175,12 +175,12 @@ test('events', async () => {
 	await umzug.up();
 
 	expect(mock.mock.calls).toMatchObject([
-		[['migrating', 'm1', { file: 'm1' }]],
-		[['up-m1']],
-		[['migrated', 'm1', { file: 'm1' }]],
-		[['migrating', 'm2', { file: 'm2' }]],
-		[['up-m2']],
-		[['migrated', 'm2', { file: 'm2' }]],
+		['migrating', 'm1', { file: 'm1' }],
+		['up-m1'],
+		['migrated', 'm1', { file: 'm1' }],
+		['migrating', 'm2', { file: 'm2' }],
+		['up-m2'],
+		['migrated', 'm2', { file: 'm2' }],
 	]);
 
 	mock.mockClear();
@@ -188,8 +188,8 @@ test('events', async () => {
 	await umzug.down();
 
 	expect(mock.mock.calls).toMatchObject([
-		[['reverting', 'm2', { file: 'm2' }]],
-		[['down-m2']],
-		[['reverted', 'm2', { file: 'm2' }]],
+		['reverting', 'm2', { file: 'm2' }],
+		['down-m2'],
+		['reverted', 'm2', { file: 'm2' }],
 	]);
 });


### PR DESCRIPTION
also decouple js from sql test fixtures

Follow-on from the discussion in a previous PR where we toyed with the idea of making the EventEmitter methods type declarations only. That'd work, but it occurred to me that we should probably have a test that makes sure the events are emitted at the right times.