### PR TITLE
fix: workaround sequelize types in tests

### DIFF
--- a/test/storage/sequelize.test.ts
+++ b/test/storage/sequelize.test.ts
@@ -9,7 +9,7 @@ import { v4 as uuid } from 'uuid';
 import jetpack = require('fs-jetpack');
 
 // TODO [sequelize@>=6.0.0] remove when sequelize fixes the types bug
-// a change in the types of sequelize@next makes `describe` a static function
+// a change in the types of sequelize@next makes `describe` a static function - see https://github.com/sequelize/sequelize/issues/12296
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 const describeModel = (model: sequelize.Model) => model.describe();

--- a/test/storage/sequelize.test.ts
+++ b/test/storage/sequelize.test.ts
@@ -8,11 +8,9 @@ import { join } from 'path';
 import { v4 as uuid } from 'uuid';
 import jetpack = require('fs-jetpack');
 
-// TODO [sequelize@>=6.0.0] remove when sequelize fixes the types bug
-// a change in the types of sequelize@next makes `describe` a static function - see https://github.com/sequelize/sequelize/issues/12296
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-const describeModel = (model: sequelize.Model) => model.describe();
+// TODO [>=3.0.0]: Investigate whether we are mis-using `model.describe()` here, and get rid of `any`.
+// See https://github.com/sequelize/umzug/pull/226 and https://github.com/sequelize/sequelize/issues/12296 for details
+const describeModel = (model: any) => model.describe();
 
 describe('sequelize', () => {
 	jetpack.cwd(__dirname).dir('tmp', { empty: true });

--- a/test/storage/sequelize.test.ts
+++ b/test/storage/sequelize.test.ts
@@ -8,6 +8,12 @@ import { join } from 'path';
 import { v4 as uuid } from 'uuid';
 import jetpack = require('fs-jetpack');
 
+// TODO [sequelize@>6.0.0] remove when sequelize fixes the types bug
+// a change in the types of sequelize@next makes `describe` a static function
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+const describeModel = (model: sequelize.Model) => model.describe();
+
 describe('sequelize', () => {
 	jetpack.cwd(__dirname).dir('tmp', { empty: true });
 
@@ -43,7 +49,7 @@ describe('sequelize', () => {
 			expect(storage.model.getTableName()).toBe('SequelizeMeta');
 			return storage.model
 				.sync()
-				.then(model => model.describe()) // a change in the types of sequelize@next makes `describe` a static function
+				.then(describeModel)
 				.then(description => {
 					expect(description).toMatchInlineSnapshot(`
 						Object {
@@ -90,7 +96,7 @@ describe('sequelize', () => {
 			});
 			return storage.model
 				.sync()
-				.then(model => model.describe()) // a change in the types of sequelize@next makes `describe` a static function
+				.then(describeModel)
 				.then(description => {
 					expect(description).toMatchInlineSnapshot(`
 						Object {
@@ -112,7 +118,7 @@ describe('sequelize', () => {
 			});
 			return storage.model
 				.sync()
-				.then(model => model.describe()) // a change in the types of sequelize@next makes `describe` a static function
+				.then(describeModel)
 				.then(description => {
 					expect(description).toMatchInlineSnapshot(`
 						Object {
@@ -146,7 +152,7 @@ describe('sequelize', () => {
 			});
 			return storage.model
 				.sync()
-				.then(model => model.describe()) // a change in the types of sequelize@next makes `describe` a static function
+				.then(describeModel)
 				.then(description => {
 					expect(description.name.type).toBe('VARCHAR(190)');
 					// Expect(description.name.defaultValue).to.be.oneOf([null, undefined])

--- a/test/storage/sequelize.test.ts
+++ b/test/storage/sequelize.test.ts
@@ -43,7 +43,7 @@ describe('sequelize', () => {
 			expect(storage.model.getTableName()).toBe('SequelizeMeta');
 			return storage.model
 				.sync()
-				.then(model => model.describe())
+				.then(model => model.describe()) // a change in the types of sequelize@next makes `describe` a static function
 				.then(description => {
 					expect(description).toMatchInlineSnapshot(`
 						Object {
@@ -90,7 +90,7 @@ describe('sequelize', () => {
 			});
 			return storage.model
 				.sync()
-				.then(model => model.describe())
+				.then(model => model.describe()) // a change in the types of sequelize@next makes `describe` a static function
 				.then(description => {
 					expect(description).toMatchInlineSnapshot(`
 						Object {
@@ -112,7 +112,7 @@ describe('sequelize', () => {
 			});
 			return storage.model
 				.sync()
-				.then(model => model.describe())
+				.then(model => model.describe()) // a change in the types of sequelize@next makes `describe` a static function
 				.then(description => {
 					expect(description).toMatchInlineSnapshot(`
 						Object {
@@ -146,7 +146,7 @@ describe('sequelize', () => {
 			});
 			return storage.model
 				.sync()
-				.then(model => model.describe())
+				.then(model => model.describe()) // a change in the types of sequelize@next makes `describe` a static function
 				.then(description => {
 					expect(description.name.type).toBe('VARCHAR(190)');
 					// Expect(description.name.defaultValue).to.be.oneOf([null, undefined])

--- a/test/storage/sequelize.test.ts
+++ b/test/storage/sequelize.test.ts
@@ -8,7 +8,7 @@ import { join } from 'path';
 import { v4 as uuid } from 'uuid';
 import jetpack = require('fs-jetpack');
 
-// TODO [sequelize@>6.0.0] remove when sequelize fixes the types bug
+// TODO [sequelize@>=6.0.0] remove when sequelize fixes the types bug
 // a change in the types of sequelize@next makes `describe` a static function
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore


### PR DESCRIPTION
One of the travis jobs runs `npm install sequelize@next`, which now breaks us. This gets things green again with a workaround. I've put in a todo that will become a lint error when we're on a stable version of sequelize using [expiring-todo-comments](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/expiring-todo-comments.md), to make sure we remember to clean up the workaround.