### PR TITLE
ci: create starter github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: echo Hello, world!


### PR DESCRIPTION
This adds a placeholder github action. The file needs to exist on master before the action will run on branches/forks, so I just want to put a v simple one in before iterating on it.

@papb after the test refactor we're at pretty much 100% code coverage. After this, I'd like to add coverage reporting to PRs/branches - jest/github actions/codecov make it really easy to do without having to setup or configure permissions for any additional accounts.