### PR TITLE
ignore null values in sequelize storage

### DIFF
--- a/src/storage/sequelize.ts
+++ b/src/storage/sequelize.ts
@@ -143,14 +143,18 @@ export class SequelizeStorage implements UmzugStorage {
 	async executed(): Promise<string[]> {
 		await this.model.sync();
 		const migrations: any[] = await this.model.findAll({ order: [[this.columnName, 'ASC']] });
-		return migrations.map(migration => {
+		return migrations.reduce((migrations, migration) => {
 			const name = migration[this.columnName];
+			if (name === null) {
+				return migrations;
+			}
 			if (typeof name !== 'string') {
 				throw new TypeError(`Unexpected migration name type: expected string, got ${typeof name}`);
 			}
 
-			return name;
-		});
+			migrations.push(name);
+			return migrations;
+		}, []);
 	}
 
 	// TODO remove this

--- a/src/storage/sequelize.ts
+++ b/src/storage/sequelize.ts
@@ -143,18 +143,16 @@ export class SequelizeStorage implements UmzugStorage {
 	async executed(): Promise<string[]> {
 		await this.model.sync();
 		const migrations: any[] = await this.model.findAll({ order: [[this.columnName, 'ASC']] });
-		return migrations.reduce((migrations, migration) => {
-			const name = migration[this.columnName];
-			if (name === null) {
-				return migrations;
-			}
-			if (typeof name !== 'string') {
-				throw new TypeError(`Unexpected migration name type: expected string, got ${typeof name}`);
-			}
+		return migrations
+			.filter((migration) => migration[this.columnName] !== null)
+			.map(migration => {
+				const name = migration[this.columnName];
+				if (typeof name !== 'string') {
+					throw new TypeError(`Unexpected migration name type: expected string, got ${typeof name}`);
+				}
 
-			migrations.push(name);
-			return migrations;
-		}, []);
+				return name;
+			});
 	}
 
 	// TODO remove this


### PR DESCRIPTION
Hello guys,

I like umzug a lot. But I get this error.
![image843](https://user-images.githubusercontent.com/60048565/93678045-3db85c00-faad-11ea-84ef-1c279a74f076.png)
After a lot of time I figgerd out, that I can't use a table like that to compress the migrations and seeders into one:
```sql
CREATE TABLE ".migrations" (
	"id"	INTEGER,
	"migrations"	VARCHAR(255),
	"seeders"	VARCHAR(255),
	"createdAt"	DATETIME NOT NULL,
	"updatedAt"	DATETIME NOT NULL,
	PRIMARY KEY("id" AUTOINCREMENT)
);
```
I think it would be a good idea to reduce the array insted of map it and throw an error if it isn't a string.

I'm not so familar with typescript. If there are types missing please add it.