### PR TITLE
fix: import sequelize as a type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,7 @@ module.exports = {
 		'jest/expect-expect': ['error', { assertFunctionNames: ['expect', 'expectTypeOf', 'verify'] }],
 
 		'@typescript-eslint/ban-types': 'off',
-		'@typescript-eslint/ban-ts-comment': ['warn', { 'ts-expect-error': false }],
+		'@typescript-eslint/ban-ts-comment': 'off', // covered by prefer-ts-expect-error
 		'@typescript-eslint/prefer-function-type': 'error',
 		'@typescript-eslint/restrict-template-expressions': 'error',
 		'@typescript-eslint/no-shadow': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,13 @@ module.exports = {
 		'jest/expect-expect': ['error', { assertFunctionNames: ['expect', 'expectTypeOf', 'verify'] }],
 
 		'@typescript-eslint/ban-types': 'off',
-		'@typescript-eslint/ban-ts-comment': 'off', // covered by prefer-ts-expect-error
+		'@typescript-eslint/ban-ts-comment': [
+			'warn',
+			{
+				'ts-expect-error': 'allow-with-description',
+				'ts-ignore': 'allow-with-description', // even with description, prefer-ts-expect-error still applies
+			},
+		],
 		'@typescript-eslint/prefer-function-type': 'error',
 		'@typescript-eslint/restrict-template-expressions': 'error',
 		'@typescript-eslint/no-shadow': 'error',

--- a/src/storage/sequelize.ts
+++ b/src/storage/sequelize.ts
@@ -1,7 +1,7 @@
 import { UmzugStorage } from './contract';
 import { SetRequired } from 'type-fest';
 // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
-// @ts-ignore this avoids typescript errors for users not using sequelize
+// @ts-ignore (Avoid type errors for non-sequelize users. Can't use ts-expect-error; this _won't_ be an error when sequelize is installed)
 import type { Sequelize as SequelizeType, Model as ModelClass } from 'sequelize';
 
 interface ModelTempInterface extends ModelClass {

--- a/src/storage/sequelize.ts
+++ b/src/storage/sequelize.ts
@@ -1,6 +1,8 @@
 import { UmzugStorage } from './contract';
 import { SetRequired } from 'type-fest';
-import { Sequelize as SequelizeType, Model as ModelClass } from 'sequelize';
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore this avoids typescript errors for users not using sequelize
+import type { Sequelize as SequelizeType, Model as ModelClass } from 'sequelize';
 
 interface ModelTempInterface extends ModelClass {
 	[key: string]: any;

--- a/test/storage/sequelize.test.ts
+++ b/test/storage/sequelize.test.ts
@@ -32,8 +32,11 @@ describe('sequelize', () => {
 
 	describe('constructor', () => {
 		it('requires a "sequelize" or "model" storage option', () => {
-			// @ts-expect-error
+			// @ts-expect-error (type error for no params)
 			expect(() => new Storage()).toThrowError('One of "sequelize" or "model" storage option is required');
+
+			// @ts-expect-error (type error for params with missing properties)
+			expect(() => new Storage({})).toThrowError('One of "sequelize" or "model" storage option is required');
 		});
 
 		it('stores needed options', () => {

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -421,7 +421,7 @@ describe('types', () => {
 		up.toBeCallableWith({ migrations: ['m1'], rerun: 'xyztypo' });
 
 		// @ts-expect-error (rerun must be specified with `migrations`)
-		up.toBeCallableWith({ rerun: 'xyztypo' });
+		up.toBeCallableWith({ rerun: 'ALLOW' });
 
 		// @ts-expect-error (can't go up "to" 0)
 		up.toBeCallableWith({ to: 0 });
@@ -440,7 +440,7 @@ describe('types', () => {
 		down.toBeCallableWith({ migrations: ['m1'], rerun: 'xyztypo' });
 
 		// @ts-expect-error (rerun can only be specified with `migrations`)
-		down.toBeCallableWith({ rerun: 'xyztypo' });
+		down.toBeCallableWith({ rerun: 'ALLOW' });
 
 		down.toBeCallableWith({ to: 0 });
 

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -417,16 +417,13 @@ describe('types', () => {
 		up.toBeCallableWith({ migrations: ['m1'], rerun: 'SKIP' });
 		up.toBeCallableWith({ migrations: ['m1'], rerun: 'THROW' });
 
-		// don't allow general strings for rerun behavior
-		// @ts-expect-error
+		// @ts-expect-error (don't allow general strings for rerun behavior)
 		up.toBeCallableWith({ migrations: ['m1'], rerun: 'xyztypo' });
 
-		// rerun must be specified with `migrations`
-		// @ts-expect-error
+		// @ts-expect-error (rerun must be specified with `migrations`)
 		up.toBeCallableWith({ rerun: 'xyztypo' });
 
-		// can't go up "to" 0
-		// @ts-expect-error
+		// @ts-expect-error (can't go up "to" 0)
 		up.toBeCallableWith({ to: 0 });
 
 		down.toBeCallableWith({ to: 'migration123' });
@@ -439,22 +436,18 @@ describe('types', () => {
 		down.toBeCallableWith({ migrations: ['m1'], rerun: 'SKIP' });
 		down.toBeCallableWith({ migrations: ['m1'], rerun: 'THROW' });
 
-		// don't allow general strings for rerun behavior
-		// @ts-expect-error
+		// @ts-expect-error (don't allow general strings for rerun behavior)
 		down.toBeCallableWith({ migrations: ['m1'], rerun: 'xyztypo' });
 
-		// rerun can only be specified with `migrations`
-		// @ts-expect-error
+		// @ts-expect-error (rerun can only be specified with `migrations`)
 		down.toBeCallableWith({ rerun: 'xyztypo' });
 
 		down.toBeCallableWith({ to: 0 });
 
-		// `{ to: 0 }` is a special case. `{ to: 1 }` shouldn't be allowed:
-
-		// @ts-expect-error
+		// @ts-expect-error (`{ to: 0 }` is a special case. `{ to: 1 }` shouldn't be allowed)
 		down.toBeCallableWith({ to: 1 });
 
-		// @ts-expect-error
+		// @ts-expect-error (`{ to: 0 }` is a special case. `{ to: 1 }` shouldn't be allowed)
 		up.toBeCallableWith({ to: 1 });
 	});
 


### PR DESCRIPTION
also ignore errors when importing, so users not using sequelize storage don't hit typescript errors

Fixes #348 