### PR TITLE
chore(renovate): group dev dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,22 +5,13 @@
     ":semanticCommits"
   ],
   "prConcurrentLimit": 4,
+  "dependencyDashboard": true,
+  "dependencyDashboardAutoclose": true,
   "packageRules": [
     {
       "depTypeList": ["devDependencies"],
+      "groupName": "devDependencies",
       "automerge": true
-    },
-    {
-      "depTypeList": ["devDependencies"],
-      "packagePatterns": ["eslint", "prettier"],
-      "groupName": "lint packages",
-      "labels": ["lint"]
-    },
-    {
-      "depTypeList": ["devDependencies"],
-      "packagePatterns": ["jest"],
-      "groupName": "test packages",
-      "labels": ["test"]
     }
   ]
 }


### PR DESCRIPTION
@papb last PR for today, I promise!

This groups all dev dependencies together so we'll get less renovate noise. The tradeoff is, if builds fail, it won't be as immediately obvious which package caused the error. I think worth it since errors for dev dependencies are usually pretty easy to understand.

Once this has gone in and created a dependency dashboard issue, I'd propose we add the `schedule:weekly` config too.