### PR TITLE
feat: return migration meta from up/down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ umzug.json
 .vscode
 coverage
 test/generated
+*.tgz

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -234,7 +234,7 @@ export class Umzug<Ctx> extends EventEmitter {
 	 * Apply migrations. By default, runs all pending migrations.
 	 * @see MigrateUpOptions for other use cases using `to`, `migrations` and `rerun`.
 	 */
-	async up(options: MigrateUpOptions = {}): Promise<void> {
+	async up(options: MigrateUpOptions = {}): Promise<MigrationMeta[]> {
 		const eligibleMigrations = async () => {
 			if (options.migrations && options.rerun === RerunBehavior.ALLOW) {
 				// Allow rerun means the specified migrations should be run even if they've run before - so get all migrations, not just pending
@@ -277,13 +277,15 @@ export class Umzug<Ctx> extends EventEmitter {
 			this.logging(`== ${m.name}: migrated (${duration}s)\n`);
 			this.emit('migrated', m.name, m);
 		}
+
+		return toBeApplied.map(m => ({ name: m.name, path: m.path }));
 	}
 
 	/**
 	 * Revert migrations. By default, the last executed migration is reverted.
 	 * @see MigrateDownOptions for other use cases using `to`, `migrations` and `rerun`.
 	 */
-	async down(options: MigrateDownOptions = {}): Promise<void> {
+	async down(options: MigrateDownOptions = {}): Promise<MigrationMeta[]> {
 		const eligibleMigrations = async () => {
 			if (options.migrations && options.rerun === RerunBehavior.ALLOW) {
 				const list = await this.migrations();
@@ -327,6 +329,8 @@ export class Umzug<Ctx> extends EventEmitter {
 			this.logging(`== ${m.name}: reverted (${duration}s)\n`);
 			this.emit('reverted', m.name, m);
 		}
+
+		return toBeReverted.map(m => ({ name: m.name, path: m.path }));
 	}
 
 	private findNameIndex(migrations: Array<RunnableMigration<Ctx>>, name: string) {

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -243,6 +243,28 @@ describe('alternate migration inputs', () => {
 		]);
 	});
 
+	test('up and down return migration meta array', async () => {
+		const umzug = new Umzug({
+			migrations: [
+				{ name: 'm1', path: 'm1.sql', up: async () => {} },
+				{ name: 'm2', path: 'm2.sql', up: async () => {} },
+			],
+			logger: undefined,
+		});
+
+		const upResults = await umzug.up();
+		expect(upResults).toEqual([
+			{ name: 'm1', path: 'm1.sql' },
+			{ name: 'm2', path: 'm2.sql' },
+		]);
+
+		const downResults = await umzug.down({ to: 0 });
+		expect(downResults).toEqual([
+			{ name: 'm2', path: 'm2.sql' },
+			{ name: 'm1', path: 'm1.sql' },
+		]);
+	});
+
 	test('with migrations array', async () => {
 		const spy = jest.fn();
 
@@ -514,6 +536,9 @@ describe('types', () => {
 
 		// @ts-expect-error (`{ to: 0 }` is a special case. `{ to: 1 }` shouldn't be allowed)
 		up.toBeCallableWith({ to: 1 });
+
+		up.returns.toEqualTypeOf<Promise<Array<{ name: string; path?: string }>>>();
+		down.returns.toEqualTypeOf<Promise<Array<{ name: string; path?: string }>>>();
 	});
 
 	test('pending', () => {


### PR DESCRIPTION
v2 returned a list of `name` and `file` values from `up` and `down`, which was useful for inspecting what just happened. This adds the equivalent.