### PR TITLE
Support `step` in up and down options

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ It is also possible to pass the name of a migration in order to just run the mig
 await umzug.up({ to: '20141101203500-task' });
 ```
 
+To limit the number of migrations that are run, `step` can be used:
+
+```js
+await umzug.up({ step: 2 })
+```
 
 Running specific migrations while ignoring the right order, can be done like this:
 
@@ -208,6 +213,12 @@ The `down` method can be used to revert the last executed migration.
 ```js
 const migration = await umzug.down();
 // reverts the last migration and returns it.
+```
+
+To revert more than one migration, you can use `step`:
+
+```js
+await umzug.down({ step: 2 });
 ```
 
 It is possible to pass the name of a migration until which (inclusive) the migrations should be reverted. This allows the reverting of multiple migrations at once.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9075,8 +9075,7 @@
 		"type-fest": {
 			"version": "0.19.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.19.0.tgz",
-			"integrity": "sha512-6lN0zC9ItzVv3jq9NicSaqo7PUjTNnmxGBECiJbz8Vv2TWaGW15mJTBS2BHZUlEKRsclzZzp8gHnBe4kzQRNfg==",
-			"dev": true
+			"integrity": "sha512-6lN0zC9ItzVv3jq9NicSaqo7PUjTNnmxGBECiJbz8Vv2TWaGW15mJTBS2BHZUlEKRsclzZzp8gHnBe4kzQRNfg=="
 		},
 		"typedarray-to-buffer": {
 			"version": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 	],
 	"dependencies": {
 		"fs-jetpack": "^4.0.0",
-		"glob": "^7.1.6"
+		"glob": "^7.1.6",
+		"type-fest": "^0.19.0"
 	},
 	"devDependencies": {
 		"@types/jest": "26.0.15",
@@ -43,7 +44,6 @@
 		"source-map-support": "0.5.19",
 		"sqlite3": "5.0.0",
 		"ts-jest": "26.4.4",
-		"type-fest": "0.19.0",
 		"typescript": "4.0.5",
 		"uuid": "8.3.1"
 	},

--- a/src/type-util.ts
+++ b/src/type-util.ts
@@ -1,0 +1,7 @@
+import * as typeFest from 'type-fest';
+
+/**
+ * Create a type that has mutually exclusive keys.
+ * Wrapper for @see `import('type-fest').MergeExclusive` that works for three types
+ */
+export type MergeExclusive<A, B, C> = typeFest.MergeExclusive<A, typeFest.MergeExclusive<B, C>>;

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -163,6 +163,28 @@ describe('alternate migration inputs', () => {
 		expect(names(await umzug.pending())).toEqual(['m5', 'm6', 'm7']);
 	});
 
+	test('up and down with step', async () => {
+		const umzug = new Umzug({
+			migrations: [
+				{ name: 'm1', up: async () => {} },
+				{ name: 'm2', up: async () => {} },
+				{ name: 'm3', up: async () => {} },
+				{ name: 'm4', up: async () => {} },
+			],
+			logger: undefined,
+		});
+
+		await umzug.up({ step: 3 });
+
+		expect(names(await umzug.executed())).toEqual(['m1', 'm2', 'm3']);
+		expect(names(await umzug.pending())).toEqual(['m4']);
+
+		await umzug.down({ step: 2 });
+
+		expect(names(await umzug.executed())).toEqual(['m1']);
+		expect(names(await umzug.pending())).toEqual(['m2', 'm3', 'm4']);
+	});
+
 	test('up and down options', async () => {
 		const spy = jest.fn();
 		const umzug = new Umzug({


### PR DESCRIPTION
I've been playing around with a CLI, and loosely basing some of the features on [knex-migrate](https://npmjs.com/package/knex-migrate). One thing that library has that umzug doesn't is support for running fewer-than-all up migrations, or more-than-one down migrations without having to specify the name of the target migration.