### PR TITLE
Log json-able objects instead of strings

### DIFF
--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -9,14 +9,14 @@ const globAsync = promisify(glob);
 
 export type Promisable<T> = T | PromiseLike<T>;
 
-export type LogFn = (message: string) => void;
+export type LogFn = (message: Record<string, unknown>) => void;
 
 /** Constructor options for the Umzug class */
 export interface UmzugOptions<Ctx = never> {
 	/** The migrations that the Umzug instance should perform */
 	migrations: InputMigrations<Ctx>;
 	/** A logging function. Pass `console` to use stdout, or pass in your own logger. Pass `undefined` explicitly to disable logging. */
-	logger: Record<'info' | 'warn' | 'error', LogFn> | undefined;
+	logger: Record<'info' | 'warn' | 'error' | 'debug', LogFn> | undefined;
 	/** The storage implementation. By default, `JSONStorage` will be used */
 	storage?: UmzugStorage;
 	/** An optional context object, which will be passed to each migration function, if defined */
@@ -151,7 +151,7 @@ export class Umzug<Ctx> extends EventEmitter {
 		this.migrations = this.getMigrationsResolver();
 	}
 
-	private logging(message: string) {
+	private logging(message: Record<string, unknown>) {
 		this.options.logger?.info(message);
 	}
 
@@ -275,15 +275,15 @@ export class Umzug<Ctx> extends EventEmitter {
 
 		for (const m of toBeApplied) {
 			const start = Date.now();
-			this.logging('== ' + m.name + ': migrating =======');
+			this.logging({ event: 'migrating', name: m.name });
 			this.emit('migrating', m.name, m);
 
 			await m.up({ name: m.name, path: m.path, context: this.options.context });
 
 			await this.storage.logMigration(m.name);
 
-			const duration = ((Date.now() - start) / 1000).toFixed(3);
-			this.logging(`== ${m.name}: migrated (${duration}s)\n`);
+			const duration = Number.parseFloat(((Date.now() - start) / 1000).toFixed(3));
+			this.logging({ event: 'migrated', name: m.name, durationSeconds: duration });
 			this.emit('migrated', m.name, m);
 		}
 
@@ -327,15 +327,15 @@ export class Umzug<Ctx> extends EventEmitter {
 
 		for (const m of toBeReverted) {
 			const start = Date.now();
-			this.logging('== ' + m.name + ': reverting =======');
+			this.logging({ event: 'reverting', name: m.name });
 			this.emit('reverting', m.name, m);
 
 			await m.down?.({ name: m.name, path: m.path, context: this.options.context });
 
 			await this.storage.unlogMigration(m.name);
 
-			const duration = ((Date.now() - start) / 1000).toFixed(3);
-			this.logging(`== ${m.name}: reverted (${duration}s)\n`);
+			const duration = Number.parseFloat(((Date.now() - start) / 1000).toFixed(3));
+			this.logging({ event: 'reverted', name: m.name, durationSeconds: duration });
 			this.emit('reverted', m.name, m);
 		}
 

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -282,7 +282,7 @@ export class Umzug<Ctx> extends EventEmitter {
 
 			await this.storage.logMigration(m.name);
 
-			const duration = Number.parseFloat(((Date.now() - start) / 1000).toFixed(3));
+			const duration = (Date.now() - start) / 1000;
 			this.logging({ event: 'migrated', name: m.name, durationSeconds: duration });
 			this.emit('migrated', m.name, m);
 		}

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -530,7 +530,7 @@ describe('types', () => {
 			context: { foo: 123 },
 			logger: {
 				...console,
-				info: (...args) => expectTypeOf(args).toEqualTypeOf<[string]>(),
+				info: (...args) => expectTypeOf(args).toEqualTypeOf<[Record<string, unknown>]>(),
 			},
 		});
 	});
@@ -755,15 +755,18 @@ describe('custom logger', () => {
 				info: spy,
 				warn: spy,
 				error: spy,
+				debug: spy,
 			},
 		});
 
 		await umzug.up();
 
 		expect(spy).toHaveBeenCalledTimes(2);
-		expect(spy.mock.calls.map(c => c[0].replace(/\d.\d{3}s/, '0.000s'))).toEqual([
-			'== m1: migrating =======',
-			'== m1: migrated (0.000s)\n',
+		expect(
+			spy.mock.calls.map(([c]) => ({ ...c, durationSeconds: c.durationSeconds && Math.floor(c.durationSeconds) }))
+		).toEqual([
+			{ event: 'migrating', name: 'm1' },
+			{ event: 'migrated', name: 'm1', durationSeconds: 0 },
 		]);
 	});
 });


### PR DESCRIPTION
Implements https://github.com/sequelize/umzug/discussions/326#discussioncomment-98776

This updates the expected log function format to accept objects instead of strings. Users can always format to strings if they want, but this allows easier integration with json-based logging system. `console` is still an OK logger to pass in and will print out readable logs. 

CC @stefaanMLB