### PR TITLE
Typed async events

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,20 @@ The `migrations.resolve` parameter replaces `customResolver`. Explicit support f
 
 The constructor option `logging` is replaced by `logger` to allow for `warn` and `error` messages in future. NodeJS's global `console` object can be passed to this. To disable logging, replace `logging: false` with `logger: undefined`.
 
+Events have moved from the default nodejs `EventEmitter` to [emittery](https://www.npmjs.com/package/emittery). It has better design for async code, a less bloated API surface and strong types. But, it doesn't allow passing multiple arguments to callbacks, so listeners have to change slightly:
+
+Before:
+
+```js
+umzug.on('migrating', (name, m) => console.log({ name, path: m.path }))
+```
+
+After:
+
+```js
+umzug.on('migrating', ev => console.log({ name: ev.name, path: ev.path }))
+```
+
 The `Umzug#execute` method is removed. Use `Umzug#up` or `Umzug#down`.
 
 The options for `Umguz#up` and `Umzug#down` have changed:
@@ -498,12 +512,14 @@ class CustomStorage implements UmzugStorage {
 
 ### Events
 
-Umzug is an [EventEmitter](https://nodejs.org/docs/latest-v10.x/api/events.html#events_class_eventemitter). Each of the following events will be called with `name` and `migration` as arguments. Events are a convenient place to implement application-specific logic that must run around each migration:
+Umzug is an [emittery event emitter](https://www.npmjs.com/package/emittery). Each of the following events will be called with migration parameters as its payload (with `context`, `name`, and nullable `path` properties). Events are a convenient place to implement application-specific logic that must run around each migration:
 
 * `migrating` - A migration is about to be executed.
 * `migrated` - A migration has successfully been executed.
 * `reverting` - A migration is about to be reverted.
 * `reverted` - A migration has successfully been reverted.
+
+All events are type-safe, so IDEs will prevent typos and supply strong types for the event payloads.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ The `migrations.resolve` parameter replaces `customResolver`. Explicit support f
 
 The constructor option `logging` is replaced by `logger` to allow for `warn` and `error` messages in future. NodeJS's global `console` object can be passed to this. To disable logging, replace `logging: false` with `logger: undefined`.
 
-Events have moved from the default nodejs `EventEmitter` to [emittery](https://www.npmjs.com/package/emittery). It has better design for async code, a less bloated API surface and strong types. But, it doesn't allow passing multiple arguments to callbacks, so listeners have to change slightly:
+Events have moved from the default nodejs `EventEmitter` to [emittery](https://www.npmjs.com/package/emittery). It has better design for async code, a less bloated API surface and strong types. But, it doesn't allow passing multiple arguments to callbacks, so listeners have to change slightly, as well as `.addListener(...)` and `.removeListener(...)` no longer being supported (`.on(...)` and `.off(...)` should now be used):
 
 Before:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2463,8 +2463,7 @@
 		"emittery": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
-			"integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
-			"dev": true
+			"integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ=="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
 		"lib"
 	],
 	"dependencies": {
-		"emittery": "^0.7.2",
-		"fs-jetpack": "^4.0.0",
-		"glob": "^7.1.6",
-		"type-fest": "^0.19.0"
+		"emittery": "~0.7.2",
+		"fs-jetpack": "~4.0.0",
+		"glob": "~7.1.6",
+		"type-fest": "~0.19.0"
 	},
 	"devDependencies": {
 		"@types/jest": "26.0.15",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"lib"
 	],
 	"dependencies": {
+		"emittery": "^0.7.2",
 		"fs-jetpack": "^4.0.0",
 		"glob": "^7.1.6",
 		"type-fest": "^0.19.0"

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -3,7 +3,7 @@ import { promisify } from 'util';
 import { UmzugStorage, JSONStorage, verifyUmzugStorage } from './storage';
 import * as glob from 'glob';
 import { MergeExclusive } from './type-util';
-import { Typed as EventEmitter } from 'emittery';
+import * as emittery from 'emittery';
 
 const globAsync = promisify(glob);
 
@@ -121,7 +121,7 @@ export type MigrateDownOptions = MergeExclusive<
 	}
 >;
 
-export class Umzug<Ctx> extends EventEmitter<
+export class Umzug<Ctx> extends emittery.Typed<
 	Record<'migrating' | 'migrated' | 'reverting' | 'reverted', MigrationParams<Ctx>>
 > {
 	private readonly storage: UmzugStorage;

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -642,6 +642,38 @@ describe('types', () => {
 			return migrations.slice();
 		});
 	});
+
+	test('event types', () => {
+		const umzug = new Umzug({
+			migrations: [],
+			context: { someCustomSqlClient: {} },
+			logger: undefined,
+		});
+
+		umzug.on('migrating', params => {
+			expectTypeOf(params.name).toBeString();
+			expectTypeOf(params.path).toEqualTypeOf<string | undefined>();
+			expectTypeOf(params.context).toEqualTypeOf({ someCustomSqlClient: {} });
+		});
+
+		umzug.on('migrated', params => {
+			expectTypeOf(params.name).toBeString();
+			expectTypeOf(params.path).toEqualTypeOf<string | undefined>();
+			expectTypeOf(params.context).toEqualTypeOf({ someCustomSqlClient: {} });
+		});
+
+		umzug.on('reverting', params => {
+			expectTypeOf(params.name).toBeString();
+			expectTypeOf(params.path).toEqualTypeOf<string | undefined>();
+			expectTypeOf(params.context).toEqualTypeOf({ someCustomSqlClient: {} });
+		});
+
+		umzug.on('reverted', params => {
+			expectTypeOf(params.name).toBeString();
+			expectTypeOf(params.path).toEqualTypeOf<string | undefined>();
+			expectTypeOf(params.context).toEqualTypeOf({ someCustomSqlClient: {} });
+		});
+	});
 });
 
 describe('error cases', () => {
@@ -703,23 +735,22 @@ describe('events', () => {
 			logger: undefined,
 		});
 
-		// `.addListener` and `.on` are aliases - use both to make sure they're wired up properly
-		umzug.addListener('migrating', spy('migrating'));
+		umzug.on('migrating', spy('migrating'));
 		umzug.on('migrated', spy('migrated'));
 
 		const revertingSpy = spy('reverting');
-		umzug.addListener('reverting', revertingSpy);
+		umzug.on('reverting', revertingSpy);
 		umzug.on('reverted', spy('reverted'));
 
 		await umzug.up();
 
 		expect(mock.mock.calls).toMatchObject([
-			['migrating', 'm1', { name: 'm1' }],
+			['migrating', { name: 'm1' }],
 			['up-m1', { name: 'm1' }],
-			['migrated', 'm1', { name: 'm1' }],
-			['migrating', 'm2', { name: 'm2' }],
+			['migrated', { name: 'm1' }],
+			['migrating', { name: 'm2' }],
 			['up-m2', { name: 'm2' }],
-			['migrated', 'm2', { name: 'm2' }],
+			['migrated', { name: 'm2' }],
 		]);
 
 		mock.mockClear();
@@ -727,21 +758,21 @@ describe('events', () => {
 		await umzug.down();
 
 		expect(mock.mock.calls).toMatchObject([
-			['reverting', 'm2', { name: 'm2' }],
+			['reverting', { name: 'm2' }],
 			['down-m2', { name: 'm2' }],
-			['reverted', 'm2', { name: 'm2' }],
+			['reverted', { name: 'm2' }],
 		]);
 
 		mock.mockClear();
 
-		umzug.removeListener('reverting', revertingSpy);
+		umzug.off('reverting', revertingSpy);
 
 		await umzug.down();
 
 		expect(mock.mock.calls).toMatchObject([
 			// `reverting` shouldn't be here because the listener was removed
 			['down-m1', { name: 'm1' }],
-			['reverted', 'm1', { name: 'm1' }],
+			['reverted', { name: 'm1' }],
 		]);
 	});
 });


### PR DESCRIPTION
This switches from nodejs's `EventEmitter` to [emittery](https://npmjs.com/package/emittery) for a few reasons:

- type-safe events. This will prevent people doing things like `.on('migration', ...)` instead of `.on('migrating', ...)` etc. It also types the event payload - especially important now since the payload is changing slightly
- async events. `this.emit(...)` now returns a promise, which we can await. Which means in a follow-up, we can add `beforeAll` and `afterAll` events, which will enable use cases like locking the migration table. That wouldn't be possible with sync events.
-  apparently, less chance of memory leaks 🤷 

The API is smaller than `EventEmitter` which makes this a breaking change by itself. `emittery` only supports single payloads too, meaning we can no longer `emit('migrating', m.name, m)` - but that was pretty redundant anyway, so it makes sense to update to `MigrationParams` as part of the major (v3) release.