### PR TITLE
Add beforeAll/afterAll events + file locking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,6 +96,7 @@ module.exports = {
 		'unicorn/no-fn-reference-in-iterator': 'off',
 		'unicorn/no-null': 'off',
 		'unicorn/prevent-abbreviations': 'off',
+		'unicorn/no-useless-undefined': 'off',
 	},
 	overrides: [
 		{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,6 +89,7 @@ module.exports = {
 		'no-warning-comments': 'off',
 		'no-dupe-class-members': 'off',
 		'capitalized-comments': 'off',
+		'no-promise-executor-return': 'off',
 
 		'unicorn/catch-error-name': 'off',
 		'unicorn/consistent-function-scoping': 'off',

--- a/README.md
+++ b/README.md
@@ -519,6 +519,13 @@ Umzug is an [emittery event emitter](https://www.npmjs.com/package/emittery). Ea
 * `reverting` - A migration is about to be reverted.
 * `reverted` - A migration has successfully been reverted.
 
+These events run at the beginning and end of `up` and `down` calls. They'll receive an object containing a `context` property:
+
+- `beforeAll` - Before any of the migrations are run.
+- `afterAll` - After all the migrations have been executed. Note: this will always run, even if migrations throw an error.
+
+The [`FileLocker` class](./src/file-locker.ts) uses `beforeAll` and `afterAll` to implement a simple filesystem-based locking mechanism.
+
 All events are type-safe, so IDEs will prevent typos and supply strong types for the event payloads.
 
 ## License

--- a/src/file-locker.ts
+++ b/src/file-locker.ts
@@ -1,0 +1,89 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Umzug } from './umzug';
+
+export interface FileLockerOptions {
+	path: string;
+	fs?: typeof fs;
+}
+
+/**
+ * Simple locker using the filesystem. Only one lock can be held per file. An error will be thrown if the
+ * lock file already exists.
+ *
+ * @example
+ * const umzug = new Umzug({ ... })
+ * FileLocker.attach(umzug, { path: 'path/to/lockfile' })
+ *
+ * @docs
+ * To wait for the lock to be free instead of throwing, you could extend it (the below example uses `setInterval`,
+ * but depending on your use-case, you may want to use a library with retry/backoff):
+ *
+ * @example
+ * class WaitingFileLocker extends FileLocker {
+ *   async getLock() {
+ *     return new Promise(resolve => setInterval(
+ *       () => super.getLock().then(resolve).catch(),
+ *       500,
+ *     )
+ *   }
+ * }
+ *
+ * const locker = new WaitingFileLocker({ path: 'path/to/lockfile' })
+ * locker.attachTo(umzug)
+ */
+export class FileLocker {
+	private readonly lockFile: string;
+	private readonly fs: typeof fs;
+
+	constructor(params: FileLockerOptions) {
+		this.lockFile = params.path;
+		this.fs = params.fs ?? fs;
+	}
+
+	/** Attach `beforeAll` and `afterAll` events to an umzug instance which use the specified filepath */
+	static attach(umzug: Umzug<unknown>, params: FileLockerOptions): void {
+		const locker = new FileLocker(params);
+		locker.attachTo(umzug);
+	}
+
+	/** Attach `beforeAll` and `afterAll` events to an umzug instance */
+	attachTo(umzug: Umzug<unknown>): void {
+		umzug.on('beforeAll', async () => this.getLock());
+		umzug.on('afterAll', async () => this.releaseLock());
+	}
+
+	private async readFile(filepath: string): Promise<string | undefined> {
+		return this.fs.promises.readFile(filepath).then(
+			buf => buf.toString(),
+			() => undefined
+		);
+	}
+
+	private async writeFile(filepath: string, content: string): Promise<void> {
+		await this.fs.promises.mkdir(path.dirname(filepath), { recursive: true });
+		await this.fs.promises.writeFile(filepath, content);
+	}
+
+	private async removeFile(filepath: string): Promise<void> {
+		await this.fs.promises.unlink(filepath);
+	}
+
+	async getLock(): Promise<void> {
+		const existing = await this.readFile(this.lockFile);
+		if (existing) {
+			throw new Error(`Can't acquire lock. ${this.lockFile} exists`);
+		}
+
+		await this.writeFile(this.lockFile, 'lock');
+	}
+
+	async releaseLock(): Promise<void> {
+		const existing = await this.readFile(this.lockFile);
+		if (!existing) {
+			throw new Error(`Nothing to unlock`);
+		}
+
+		await this.removeFile(this.lockFile);
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './umzug';
 export * from './storage';
+export * from './file-locker';

--- a/test/lock.test.ts
+++ b/test/lock.test.ts
@@ -1,0 +1,39 @@
+import { JSONStorage, FileLocker, Umzug } from '../src';
+import * as path from 'path';
+import { fsSyncer } from 'fs-syncer';
+import * as pEvent from 'p-event';
+
+const names = (migrations: Array<{ name: string }>) => migrations.map(m => m.name);
+const delay = async (ms: number) => new Promise(r => setTimeout(r, ms));
+
+describe('locks', () => {
+	const syncer = fsSyncer(path.join(__dirname, 'generated/lock/json'), {});
+	syncer.sync();
+
+	test('file lock', async () => {
+		const umzug = new Umzug({
+			migrations: [1, 2].map(n => ({
+				name: `m${n}`,
+				up: async () => delay(100),
+			})),
+			storage: new JSONStorage({ path: path.join(syncer.baseDir, 'storage.json') }),
+			logger: undefined,
+		});
+
+		FileLocker.attach(umzug, { path: path.join(syncer.baseDir, 'storage.json.lock') });
+
+		expect(syncer.read()).toEqual({});
+
+		const promise1 = umzug.up();
+		await pEvent(umzug, 'migrating');
+		const promise2 = umzug.up();
+
+		await expect(promise2).rejects.toThrowError(/Can't acquire lock. (.*)storage.json.lock exists/);
+		await expect(promise1.then(names)).resolves.toEqual(['m1', 'm2']);
+
+		expect(names(await umzug.executed())).toEqual(['m1', 'm2']);
+		expect(syncer.read()).toEqual({
+			'storage.json': JSON.stringify(['m1', 'm2'], null, 2),
+		});
+	});
+});


### PR DESCRIPTION
Follow-up to #394 

This adds `beforeAll` and `afterAll` events. They run before the first and after the last migration respectively, for both `up` and `down` calls. This allows for locking functionality as requested in https://github.com/sequelize/umzug/discussions/144. Right now, there's a `FileLocker` class which uses the filesystem to implement a very basic locking mechanism. Adding actual database locking is more complex though, since every database system implements locks differently. I plan to use this to add locking to [@slonik/migrator](https://npmjs.com/package/@slonik/migrator), since that's postgresql-only. It _might_ be possible to add a `SequelizeLocker` class similar to `FileLocker` using [transactions](https://sequelize.org/master/manual/transactions.html), but if that's difficult it could come in another follow-up. @papb have you use sequelize locks before?