### PR TITLE
Pass context to storage methods

### DIFF
--- a/src/storage/contract.ts
+++ b/src/storage/contract.ts
@@ -1,18 +1,20 @@
-export interface UmzugStorage {
+import { MigrationParams } from '../umzug';
+
+export interface UmzugStorage<Ctx = unknown> {
 	/**
 	 * Logs migration to be considered as executed.
 	 */
-	logMigration: (migrationName: string) => Promise<void>;
+	logMigration: (migrationName: string, params: MigrationParams<Ctx>) => Promise<void>;
 
 	/**
 	 * Unlogs migration (makes it to be considered as pending).
 	 */
-	unlogMigration: (migrationName: string) => Promise<void>;
+	unlogMigration: (migrationName: string, params: MigrationParams<Ctx>) => Promise<void>;
 
 	/**
 	 * Gets list of executed migrations.
 	 */
-	executed: () => Promise<string[]>;
+	executed: (meta: Pick<MigrationParams<Ctx>, 'context'>) => Promise<string[]>;
 }
 
 export function isUmzugStorage(arg: Partial<UmzugStorage>): arg is UmzugStorage {

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -125,7 +125,7 @@ export class Umzug<Ctx> extends emittery.Typed<
 	Record<'migrating' | 'migrated' | 'reverting' | 'reverted', MigrationParams<Ctx>> &
 		Record<'beforeAll' | 'afterAll', { context: Ctx }>
 > {
-	private readonly storage: UmzugStorage;
+	private readonly storage: UmzugStorage<Ctx>;
 	private readonly migrations: () => Promise<ReadonlyArray<RunnableMigration<Ctx>>>;
 
 	/**
@@ -235,7 +235,10 @@ export class Umzug<Ctx> extends emittery.Typed<
 
 	/** Get the list of migrations which have already been applied */
 	private async _executed(): Promise<ReadonlyArray<RunnableMigration<Ctx>>> {
-		const [migrations, executedNames] = await Promise.all([this.migrations(), this.storage.executed()]);
+		const [migrations, executedNames] = await Promise.all([
+			this.migrations(),
+			this.storage.executed({ context: this.context }),
+		]);
 		const executedSet = new Set(executedNames);
 		return migrations.filter(m => executedSet.has(m.name));
 	}
@@ -248,7 +251,10 @@ export class Umzug<Ctx> extends emittery.Typed<
 	}
 
 	private async _pending(): Promise<Array<RunnableMigration<Ctx>>> {
-		const [migrations, executedNames] = await Promise.all([this.migrations(), this.storage.executed()]);
+		const [migrations, executedNames] = await Promise.all([
+			this.migrations(),
+			this.storage.executed({ context: this.context }),
+		]);
 		const executedSet = new Set(executedNames);
 		return migrations.filter(m => !executedSet.has(m.name));
 	}
@@ -306,7 +312,7 @@ export class Umzug<Ctx> extends emittery.Typed<
 
 				await m.up(params);
 
-				await this.storage.logMigration(m.name);
+				await this.storage.logMigration(m.name, params);
 
 				const duration = (Date.now() - start) / 1000;
 				this.logging({ event: 'migrated', name: m.name, durationSeconds: duration });
@@ -362,7 +368,7 @@ export class Umzug<Ctx> extends emittery.Typed<
 
 				await m.down?.(params);
 
-				await this.storage.unlogMigration(m.name);
+				await this.storage.unlogMigration(m.name, params);
 
 				const duration = Number.parseFloat(((Date.now() - start) / 1000).toFixed(3));
 				this.logging({ event: 'reverted', name: m.name, durationSeconds: duration });

--- a/test/storage/memory.test.ts
+++ b/test/storage/memory.test.ts
@@ -10,32 +10,32 @@ describe('memoryStorage', () => {
 
 	test('executed returns empty array when no migrations are logged', async () => {
 		const storage = memoryStorage();
-		expect(await storage.executed()).toEqual([]);
+		expect(await storage.executed({ context: {} })).toEqual([]);
 	});
 
 	test('logMigration, executed and unlogMigration', async () => {
 		const storage = memoryStorage();
 
-		await storage.logMigration('m1');
-		expect(await storage.executed()).toEqual(['m1']);
+		await storage.logMigration('m1', { name: 'm1', context: {} });
+		expect(await storage.executed({ context: {} })).toEqual(['m1']);
 
-		await storage.logMigration('m1');
-		await storage.logMigration('m2');
-		expect(await storage.executed()).toEqual(['m1', 'm1', 'm2']);
+		await storage.logMigration('m1', { name: 'm1', context: {} });
+		await storage.logMigration('m2', { name: 'm1', context: {} });
+		expect(await storage.executed({ context: {} })).toEqual(['m1', 'm1', 'm2']);
 
-		await storage.unlogMigration('m1');
-		expect(await storage.executed()).toEqual(['m2']);
+		await storage.unlogMigration('m1', { name: 'm1', context: {} });
+		expect(await storage.executed({ context: {} })).toEqual(['m2']);
 
-		await storage.unlogMigration('m2');
-		expect(await storage.executed()).toEqual([]);
+		await storage.unlogMigration('m2', { name: 'm1', context: {} });
+		expect(await storage.executed({ context: {} })).toEqual([]);
 	});
 
 	test(`executed isn't affected by side-effects`, async () => {
 		const storage = memoryStorage();
 
-		const executed = await storage.executed();
+		const executed = await storage.executed({ context: {} });
 		executed.push('abc');
 
-		expect(await storage.executed()).toEqual([]);
+		expect(await storage.executed({ context: {} })).toEqual([]);
 	});
 });

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -287,6 +287,38 @@ describe('alternate migration inputs', () => {
 		]);
 	});
 
+	test('custom storage', async () => {
+		const spy = jest.fn();
+
+		const umzug = new Umzug({
+			migrations: [{ name: 'm1', up: async () => {} }],
+			context: { someCustomSqlClient: {} },
+			storage: {
+				executed: async (...args) => spy('executed', ...args),
+				logMigration: async (...args) => spy('logMigration', ...args),
+				unlogMigration: async (...args) => spy('unlogMigration', ...args),
+			},
+			logger: undefined,
+		});
+
+		await umzug.up();
+
+		expect(spy.mock.calls).toEqual([
+			['executed', { context: { someCustomSqlClient: {} } }],
+			['logMigration', 'm1', { name: 'm1', context: { someCustomSqlClient: {} } }],
+		]);
+
+		spy.mockClear();
+		spy.mockReturnValueOnce(['m1']);
+
+		await umzug.down();
+
+		expect(spy.mock.calls).toEqual([
+			['executed', { context: { someCustomSqlClient: {} } }],
+			['unlogMigration', 'm1', { name: 'm1', context: { someCustomSqlClient: {} } }],
+		]);
+	});
+
 	test('with migrations array', async () => {
 		const spy = jest.fn();
 


### PR DESCRIPTION
This enables setting up clients in beforeAll, and attaching them to context so storages can use them.

It's a non-breaking change, since the context is passed in as an additional parameter. It'd be slightly better design to just pass the `logMigration(params)` instead of `logMigration(name, params)`, since `params` contains `name` anyway. But there are lots of breaking changes in v3 already so I didn't want to commit to yet another. @papb I'd be interested to get your take, though. We could simplify (and make breaking) in a follow up before the stable release.