### PR TITLE
Add examples folder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
 		ecmaVersion: 2018,
 		sourceType: 'module',
 		project: ['./tsconfig.eslint.json'],
-		extraFileExtensions: ['.md'],
+		extraFileExtensions: ['.md', '.mjs'],
 	},
 	plugins: ['@typescript-eslint/eslint-plugin', 'prettier', 'unicorn', 'jest', 'import', 'codegen'],
 	env: { 'jest/globals': true },
@@ -18,7 +18,7 @@ module.exports = {
 		'xo',
 		'xo-typescript',
 	],
-	ignorePatterns: ['lib', 'node_modules', 'test/generated', 'test/fixtures/javascript', 'coverage'],
+	ignorePatterns: ['lib', 'node_modules', 'test/generated', 'test/fixtures/javascript', 'coverage', 'examples/**/*.md'],
 	globals: { __dirname: true, process: true },
 	rules: {
 		'codegen/codegen': 'warn',
@@ -104,6 +104,18 @@ module.exports = {
 		{
 			files: ['test/**/*.ts'],
 			rules: {
+				'@typescript-eslint/no-unsafe-return': 'off',
+				'@typescript-eslint/no-non-null-assertion': 'off',
+			},
+		},
+		{
+			files: ['examples/**/*.{cjs,mjs,js,ts}'],
+			rules: {
+				'@typescript-eslint/no-unused-vars': 'off',
+				'unicorn/filename-case': 'off',
+				'no-console': 'off',
+				'@typescript-eslint/no-floating-promises': 'off',
+				'@typescript-eslint/no-var-requires': 'off',
 				'@typescript-eslint/no-unsafe-return': 'off',
 				'@typescript-eslint/no-non-null-assertion': 'off',
 			},

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
-node_modules
+node_modules/*
 lib
 umzug.json
 .vscode
 coverage
 test/generated
 *.tgz
+examples/*/db.sqlite
+# to make the examples realistic, they `import {} from 'umzug'`. So there's a passthrough script to the compiled library in examples/node_modules/umzug/index.js
+!examples/node_modules/umzug/*

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ npm install umzug
 * Database agnostic
 * Supports logging of migration process
 * Supports multiple storages for migration data
+* [Usage examples](./examples)
 
 ## Documentation
 
 ### Minimal Example
 
-The following example uses a Sqlite database through sequelize and persists the migration data in the database itself through the sequelize storage.
+The following example uses a Sqlite database through sequelize and persists the migration data in the database itself through the sequelize storage. There are several more involved examples covering a few different scenarios in the [examples folder](./examples).
 
 ```js
 // index.js

--- a/examples/1.sequelize-typescript/migrate.js
+++ b/examples/1.sequelize-typescript/migrate.js
@@ -1,0 +1,3 @@
+require('ts-node/register');
+
+require('./umzug').migrator.runAsCLI();

--- a/examples/1.sequelize-typescript/migrations/2020.11.24T16.52.04.users-table.ts
+++ b/examples/1.sequelize-typescript/migrations/2020.11.24T16.52.04.users-table.ts
@@ -1,0 +1,20 @@
+import { DataTypes } from 'sequelize';
+import { Migration } from '../umzug';
+
+export const up: Migration = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().createTable('users', {
+		id: {
+			type: DataTypes.INTEGER,
+			allowNull: false,
+			primaryKey: true,
+		},
+		name: {
+			type: DataTypes.STRING,
+			allowNull: false,
+		},
+	});
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().dropTable('users');
+};

--- a/examples/1.sequelize-typescript/readme.md
+++ b/examples/1.sequelize-typescript/readme.md
@@ -1,0 +1,16 @@
+This example shows how migrations can be written in typescript and run with the help of `ts-node`.
+
+Note:
+- The entrypoint, `migrate.js`, calls `require('ts-node/register')` before requiring the `umzug.ts` module. This enables loading of typescript modules directly, and avoids the complexity of having a separate compilation target folder.
+- `umzug.ts` exports a migration type with `export type Migration = typeof migrator._types.migration;`. This allows typescript migration files to get strongly typed parameters by importing it. See also the [custom template example](../5.custom-template) to see how to setup a template to include this automatically in every new migration.
+
+```bash
+node migrate --help # show CLI help
+
+node migrate up # apply migrations
+node migrate down # revert the last migration
+node migrate down --to 0 # revert all migrations
+node migrate up --step 2 # run only two migrations
+
+node migrate --create my-migration.ts # create a new migration file
+```

--- a/examples/1.sequelize-typescript/umzug.ts
+++ b/examples/1.sequelize-typescript/umzug.ts
@@ -1,0 +1,20 @@
+import { Umzug, SequelizeStorage } from 'umzug';
+import { Sequelize } from 'sequelize';
+
+const sequelize = new Sequelize({
+	dialect: 'sqlite',
+	storage: './db.sqlite',
+});
+
+export const migrator = new Umzug({
+	migrations: {
+		glob: ['migrations/*.ts', { cwd: __dirname }],
+	},
+	context: sequelize,
+	storage: new SequelizeStorage({
+		sequelize,
+	}),
+	logger: console,
+});
+
+export type Migration = typeof migrator._types.migration;

--- a/examples/2.es-modules/migrations/2020.11.24T16.52.04.users-table.mjs
+++ b/examples/2.es-modules/migrations/2020.11.24T16.52.04.users-table.mjs
@@ -1,0 +1,17 @@
+export const up = async ({ context: { sequelize, DataTypes } }) => {
+	await sequelize.getQueryInterface().createTable('users', {
+		id: {
+			type: DataTypes.INTEGER,
+			allowNull: false,
+			primaryKey: true,
+		},
+		name: {
+			type: DataTypes.STRING,
+			allowNull: false,
+		},
+	});
+};
+
+export const down = async ({ context: { sequelize } }) => {
+	await sequelize.getQueryInterface().dropTable('users');
+};

--- a/examples/2.es-modules/migrations/2020.11.24T18.31.34.roles-table.cjs
+++ b/examples/2.es-modules/migrations/2020.11.24T18.31.34.roles-table.cjs
@@ -1,0 +1,17 @@
+exports.up = async ({ context: { sequelize, DataTypes } }) => {
+	await sequelize.getQueryInterface().createTable('roles', {
+		id: {
+			type: DataTypes.INTEGER,
+			allowNull: false,
+			primaryKey: true,
+		},
+		name: {
+			type: DataTypes.STRING,
+			allowNull: false,
+		},
+	});
+};
+
+exports.down = async ({ context: { sequelize } }) => {
+	await sequelize.getQueryInterface().dropTable('roles');
+};

--- a/examples/2.es-modules/readme.md
+++ b/examples/2.es-modules/readme.md
@@ -1,0 +1,17 @@
+This example shows how ECMAScript modules can be used with umzug. See the `migrations.resolve` option passed to the Umzug constructor.
+
+Note that `.mjs` migrations are resolved using `import(...)` and others are resolved using `require(...)`. If you're using a setup like this one, it's recommended to use either the `.cjs` or `.mjs` extensions rather than `.js` to make sure there's no ambiguity.
+
+Also note that you may not need to use `createRequire` like this example does, depending on which dependencies you're using.
+
+Usage example:
+
+```bash
+node umzug.mjs --help
+
+node umzug.mjs up
+node umzug.mjs down
+
+node umzug.mjs create --name my-new-migration.mjs
+node umzug.mjs create --name my-new-migration.cjs
+```

--- a/examples/2.es-modules/umzug.mjs
+++ b/examples/2.es-modules/umzug.mjs
@@ -1,0 +1,41 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { Umzug, SequelizeStorage } = require('umzug');
+const { Sequelize, DataTypes } = require('sequelize');
+const path = require('path');
+
+const sequelize = new Sequelize({
+	dialect: 'sqlite',
+	storage: './db.sqlite',
+	logging: process.env.SEQUELIZE_LOG === 'true',
+});
+
+export const migrator = new Umzug({
+	migrations: {
+		glob: ['migrations/*.{js,cjs,mjs}', { cwd: path.dirname(import.meta.url.replace('file:///', '')) }],
+		resolve: params => {
+			if (params.path.endsWith('.mjs') || params.path.endsWith('.js')) {
+				const getModule = () => import(`file:///${params.path.replace(/\\/g, '/')}`)
+				return {
+					name: params.name,
+					path: params.path,
+					up: async upParams => (await getModule()).up(upParams),
+					down: async downParams => (await getModule()).up(downParams),
+				}
+			}
+			return {
+				name: params.name,
+				path: params.path,
+				...require(params.path),
+			}
+		}
+	},
+	context: { sequelize, DataTypes },
+	storage: new SequelizeStorage({
+		sequelize,
+	}),
+	logger: console,
+});
+
+migrator.runAsCLI()

--- a/examples/3.raw-sql/migrate.js
+++ b/examples/3.raw-sql/migrate.js
@@ -1,0 +1,3 @@
+require('ts-node/register/transpile-only');
+
+require('./umzug').migrator.runAsCLI();

--- a/examples/3.raw-sql/migrations/2020.11.24T18.00.40.users.sql
+++ b/examples/3.raw-sql/migrations/2020.11.24T18.00.40.users.sql
@@ -1,0 +1,1 @@
+create table users(id int, name text);

--- a/examples/3.raw-sql/migrations/down/2020.11.24T18.00.40.users.sql
+++ b/examples/3.raw-sql/migrations/down/2020.11.24T18.00.40.users.sql
@@ -1,0 +1,1 @@
+drop table users;

--- a/examples/3.raw-sql/readme.md
+++ b/examples/3.raw-sql/readme.md
@@ -1,0 +1,3 @@
+This example demonstrates how to set up umzug with a raw sql client.
+
+Note: this is really just a toy example to show how you can use pre-existing sql queries. If you want a raw sql migrator for postgres, see [@slonik/migrator](https://npmjs.com/package/@slonik/migrator). It uses umzug in a similar way, with [slonik](https://npmjs.com/package/slonik) as the underlying client, and it adds transactions, locking, supports typescript/javascript alongside sql, and some additional safety checks.

--- a/examples/3.raw-sql/umzug.ts
+++ b/examples/3.raw-sql/umzug.ts
@@ -1,0 +1,51 @@
+import { Umzug } from 'umzug';
+import { Sequelize } from 'sequelize';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const getRawSqlClient = () => {
+	// this implementation happens to use sequelize, but you may want to use a specialised sql client
+	const sequelize = new Sequelize({
+		dialect: 'sqlite',
+		storage: './db.sqlite',
+	});
+
+	return {
+		query: async (sql: string, values?: unknown[]) => sequelize.query(sql, { bind: values }),
+	};
+};
+
+export const migrator = new Umzug({
+	migrations: {
+		glob: ['migrations/*.sql', { cwd: __dirname }],
+		resolve: params => {
+			const downPath = path.join(path.dirname(params.path), 'down', path.basename(params.path));
+			return {
+				name: params.name,
+				path: params.path,
+				up: async () => params.context.query(fs.readFileSync(params.path).toString()),
+				down: async () => params.context.query(fs.readFileSync(downPath).toString()),
+			};
+		},
+	},
+	context: getRawSqlClient(),
+	storage: {
+		async executed({ context: client }) {
+			await client.query(`create table if not exists my_migrations_table(name text)`);
+			const [results] = await client.query(`select name from my_migrations_table`);
+			return results.map((r: { name: string }) => r.name);
+		},
+		async logMigration(name, { context: client }) {
+			await client.query(`insert into my_migrations_table(name) values ($1)`, [name]);
+		},
+		async unlogMigration(name, { context: client }) {
+			await client.query(`delete from my_migrations_table where name = $1`, [name]);
+		},
+	},
+	logger: console,
+	create: {
+		folder: 'migrations',
+	},
+});
+
+export type Migration = typeof migrator._types.migration;

--- a/examples/4.sequelize-seeders/migrate.js
+++ b/examples/4.sequelize-seeders/migrate.js
@@ -1,0 +1,3 @@
+require('ts-node/register');
+
+require('./umzug').migrator.runAsCLI();

--- a/examples/4.sequelize-seeders/migrations/2020.11.24T16.52.04.users-table.ts
+++ b/examples/4.sequelize-seeders/migrations/2020.11.24T16.52.04.users-table.ts
@@ -1,0 +1,20 @@
+import { DataTypes } from 'sequelize';
+import { Migration } from '../umzug';
+
+export const up: Migration = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().createTable('users', {
+		id: {
+			type: DataTypes.INTEGER,
+			allowNull: false,
+			primaryKey: true,
+		},
+		name: {
+			type: DataTypes.STRING,
+			allowNull: false,
+		},
+	});
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().dropTable('users');
+};

--- a/examples/4.sequelize-seeders/migrations/2020.11.24T18.54.32.roles.ts
+++ b/examples/4.sequelize-seeders/migrations/2020.11.24T18.54.32.roles.ts
@@ -1,0 +1,41 @@
+import { DataTypes } from 'sequelize';
+import { Migration } from '../umzug';
+
+export const up: Migration = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().createTable('roles', {
+		id: {
+			type: DataTypes.INTEGER,
+			allowNull: false,
+			primaryKey: true,
+		},
+		name: {
+			type: DataTypes.STRING,
+			allowNull: false,
+		},
+	});
+
+	await sequelize.getQueryInterface().createTable('user_roles', {
+		user_id: {
+			type: DataTypes.INTEGER,
+			allowNull: false,
+			primaryKey: true,
+			references: {
+				model: 'users',
+				key: 'id',
+			},
+		},
+		role_id: {
+			type: DataTypes.INTEGER,
+			allowNull: false,
+			primaryKey: true,
+			references: {
+				model: 'roles',
+				key: 'id',
+			},
+		},
+	});
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().dropTable('users');
+};

--- a/examples/4.sequelize-seeders/readme.md
+++ b/examples/4.sequelize-seeders/readme.md
@@ -1,0 +1,20 @@
+This example shows how to use umzug for seeding data into a database.
+
+There's nothing very special about it. It's just two separate umzug instances created - one for migrations, and one for seeders, along with `seed.js` and `migrate.js` scripts to run them.
+
+Usage example:
+
+```bash
+# show help for each script
+node migrate --help
+node seed --help
+
+node seed up # will fail, since tables haven't been created yet
+
+node migrate up # creates tables
+node seed up # inserts seed data
+
+node seed down --to 0 # removes all seed data
+
+node seed create --name more-seed-data.ts # create a placeholder migration file for inserting more seed data.
+```

--- a/examples/4.sequelize-seeders/seed.js
+++ b/examples/4.sequelize-seeders/seed.js
@@ -1,0 +1,3 @@
+require('ts-node/register');
+
+require('./umzug').seeder.runAsCLI();

--- a/examples/4.sequelize-seeders/seeders/2020.11.24T18.46.19.sample-users.ts
+++ b/examples/4.sequelize-seeders/seeders/2020.11.24T18.46.19.sample-users.ts
@@ -1,0 +1,14 @@
+import { Seeder } from '../umzug';
+
+const seedUsers = [
+	{ id: 1, name: 'Alice' },
+	{ id: 2, name: 'Bob' },
+];
+
+export const up: Seeder = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().bulkInsert('users', seedUsers);
+};
+
+export const down: Seeder = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().bulkDelete('users', { id: seedUsers.map(u => u.id) });
+};

--- a/examples/4.sequelize-seeders/seeders/2020.11.24T19.01.37.sample-user-roles.ts
+++ b/examples/4.sequelize-seeders/seeders/2020.11.24T19.01.37.sample-user-roles.ts
@@ -1,0 +1,16 @@
+import { Seeder } from '../umzug';
+
+const seedData = {
+	roles: [{ id: 1, name: 'admin' }],
+	user_roles: [{ user_id: 1, role_id: 1 }],
+};
+
+export const up: Seeder = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().bulkInsert('roles', seedData.roles);
+	await sequelize.getQueryInterface().bulkInsert('user_roles', seedData.user_roles);
+};
+
+export const down: Seeder = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().bulkDelete('user_roles', { user_id: seedData.user_roles.map(u => u.user_id) });
+	await sequelize.getQueryInterface().bulkDelete('roles', { id: seedData.roles.map(r => r.id) });
+};

--- a/examples/4.sequelize-seeders/umzug.ts
+++ b/examples/4.sequelize-seeders/umzug.ts
@@ -1,0 +1,35 @@
+import { Umzug, SequelizeStorage } from 'umzug';
+import { Sequelize } from 'sequelize';
+
+const sequelize = new Sequelize({
+	dialect: 'sqlite',
+	storage: './db.sqlite',
+});
+
+export const migrator = new Umzug({
+	migrations: {
+		glob: ['migrations/*.ts', { cwd: __dirname }],
+	},
+	context: sequelize,
+	storage: new SequelizeStorage({
+		sequelize,
+		modelName: 'migration_meta',
+	}),
+	logger: console,
+});
+
+export type Migration = typeof migrator._types.migration;
+
+export const seeder = new Umzug({
+	migrations: {
+		glob: ['seeders/*.ts', { cwd: __dirname }],
+	},
+	context: sequelize,
+	storage: new SequelizeStorage({
+		sequelize,
+		modelName: 'seeder_meta',
+	}),
+	logger: console,
+});
+
+export type Seeder = typeof seeder._types.migration;

--- a/examples/5.custom-template/migrate.js
+++ b/examples/5.custom-template/migrate.js
@@ -1,0 +1,3 @@
+require('ts-node/register');
+
+require('./umzug').migrator.runAsCLI();

--- a/examples/5.custom-template/migrations/2020.11.24T16.52.04.users-table.ts
+++ b/examples/5.custom-template/migrations/2020.11.24T16.52.04.users-table.ts
@@ -1,0 +1,20 @@
+import { Migration } from '../umzug';
+import { DataTypes } from 'sequelize';
+
+export const up: Migration = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().createTable('users', {
+		id: {
+			type: DataTypes.INTEGER,
+			allowNull: false,
+			primaryKey: true,
+		},
+		name: {
+			type: DataTypes.STRING,
+			allowNull: false,
+		},
+	});
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().dropTable('users');
+};

--- a/examples/5.custom-template/readme.md
+++ b/examples/5.custom-template/readme.md
@@ -1,0 +1,9 @@
+This example shows how to use the filesystem to get a custom project-specific template, since the template included with umzug is pretty basic.
+
+The implementation simply reads the template file from a predefined folder, but you could make the logic more complex if you wanted.
+
+Usage:
+
+```bash
+node migrate --create my-migration.ts
+```

--- a/examples/5.custom-template/template/sample-migration.ts
+++ b/examples/5.custom-template/template/sample-migration.ts
@@ -1,0 +1,12 @@
+import { Migration } from '../umzug';
+import { DataTypes } from 'sequelize';
+
+// you can put some team-specific imports/code here to be included in every migration
+
+export const up: Migration = async ({ context: sequelize }) => {
+	await sequelize.query(`raise fail('up migration not implemented')`);
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+	await sequelize.query(`raise fail('down migration not implemented')`);
+};

--- a/examples/5.custom-template/umzug.ts
+++ b/examples/5.custom-template/umzug.ts
@@ -1,0 +1,29 @@
+import { Umzug, SequelizeStorage } from 'umzug';
+import { Sequelize } from 'sequelize';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const sequelize = new Sequelize({
+	dialect: 'sqlite',
+	storage: './db.sqlite',
+});
+
+export const migrator = new Umzug({
+	migrations: {
+		glob: ['migrations/*.ts', { cwd: __dirname }],
+	},
+	context: sequelize,
+	storage: new SequelizeStorage({
+		sequelize,
+	}),
+	logger: console,
+	create: {
+		folder: 'migrations',
+		template: filepath => [
+			// read template from filesystem
+			[filepath, fs.readFileSync(path.join(__dirname, 'template/sample-migration.ts')).toString()],
+		],
+	},
+});
+
+export type Migration = typeof migrator._types.migration;

--- a/examples/6.events/migrate.js
+++ b/examples/6.events/migrate.js
@@ -1,0 +1,3 @@
+require('ts-node/register');
+
+require('./umzug').migrator.runAsCLI();

--- a/examples/6.events/migrations/2020.11.24T16.52.04.users-table.ts
+++ b/examples/6.events/migrations/2020.11.24T16.52.04.users-table.ts
@@ -1,0 +1,20 @@
+import { DataTypes } from 'sequelize';
+import { Migration } from '../umzug';
+
+export const up: Migration = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().createTable('users', {
+		id: {
+			type: DataTypes.INTEGER,
+			allowNull: false,
+			primaryKey: true,
+		},
+		name: {
+			type: DataTypes.STRING,
+			allowNull: false,
+		},
+	});
+};
+
+export const down: Migration = async ({ context: sequelize }) => {
+	await sequelize.getQueryInterface().dropTable('users');
+};

--- a/examples/6.events/readme.md
+++ b/examples/6.events/readme.md
@@ -1,0 +1,1 @@
+This example demonstrates how to use umzug events. In this example, an internal service is shut down before migrations running (hopefully, you wouldn't actually need to do this - it's just a demo of how you _could_ use the events emitted by the umzug instance).

--- a/examples/6.events/umzug.ts
+++ b/examples/6.events/umzug.ts
@@ -1,0 +1,35 @@
+import { Umzug, SequelizeStorage } from 'umzug';
+import { Sequelize } from 'sequelize';
+
+const sequelize = new Sequelize({
+	dialect: 'sqlite',
+	storage: './db.sqlite',
+});
+
+export const migrator = new Umzug({
+	migrations: {
+		glob: ['migrations/*.ts', { cwd: __dirname }],
+	},
+	context: sequelize,
+	storage: new SequelizeStorage({ sequelize }),
+	logger: console,
+});
+
+const fakeApi = {
+	shutdownInternalService: async () => {
+		console.log('shutting down...');
+	},
+	restartInternalService: async () => {
+		console.log('restarting!');
+	},
+};
+
+migrator.on('beforeAll', async () => {
+	await fakeApi.shutdownInternalService();
+});
+
+migrator.on('afterAll', async () => {
+	await fakeApi.restartInternalService();
+});
+
+export type Migration = typeof migrator._types.migration;

--- a/examples/node_modules/umzug/index.d.ts
+++ b/examples/node_modules/umzug/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../../../lib'

--- a/examples/node_modules/umzug/index.js
+++ b/examples/node_modules/umzug/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../../..')

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -1,0 +1,1 @@
+This folder contains several minimal umzug setups. You can try them out by cloning this repo, running `npm install`, then `cd`ing into the folders. Or just browse them on GitHub and copy-paste what you need. Each has a short readme.

--- a/package-lock.json
+++ b/package-lock.json
@@ -946,6 +946,12 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/lodash": {
+			"version": "4.14.165",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
+			"integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==",
+			"dev": true
+		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1472,6 +1478,12 @@
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
 			}
+		},
+		"arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -9217,6 +9229,19 @@
 				}
 			}
 		},
+		"ts-node": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.0.0.tgz",
+			"integrity": "sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==",
+			"dev": true,
+			"requires": {
+				"arg": "^4.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"source-map-support": "^0.5.17",
+				"yn": "3.1.1"
+			}
+		},
 		"tsconfig-paths": {
 			"version": "3.9.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -9760,6 +9785,12 @@
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
 			}
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "umzug",
-	"version": "3.0.0-beta-cli.12",
+	"version": "3.0.0-beta.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	},
 	"devDependencies": {
 		"@types/jest": "26.0.16",
+		"@types/lodash": "4.14.165",
 		"@types/uuid": "8.3.0",
 		"@typescript-eslint/eslint-plugin": "4.9.0",
 		"@typescript-eslint/parser": "4.9.0",
@@ -47,6 +48,7 @@
 		"sqlite3": "5.0.0",
 		"strip-ansi": "^6.0.0",
 		"ts-jest": "26.4.4",
+		"ts-node": "9.0.0",
 		"typescript": "4.1.2",
 		"uuid": "8.3.1"
 	},


### PR DESCRIPTION
Added a bunch of usage examples that go further than the readme so users can figure out how umzug can fit into their setup.

@papb sorry to put another big review on your plate! The easiest way to review will be to open the folder in the branch: https://github.com/sequelize/umzug/tree/examples-folder/examples in another tab - everything in there is new so the no real benefits of the PR diff view.