### PR TITLE
Use verror to wrap migration errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ All events are type-safe, so IDEs will prevent typos and supply strong types for
 
 ### Errors
 
-When a migration throws an error, it will be wrapped in a `MigrationError` which captures the migration metadata (name, path etc.) as well as the original error message, and _will be rethrown_. In most cases, this is exppected behaviour, and doesn't require any special handling beyond standard error logging setups.
+When a migration throws an error, it will be wrapped in a `MigrationError` which captures the migration metadata (name, path etc.) as well as the original error message, and _will be rethrown_. In most cases, this is expected behaviour, and doesn't require any special handling beyond standard error logging setups.
 
 If you expect failures and want to try to recover from them, you will need to try-catch the call to `umzug.up()`. You can access the original error from the `.cause` property if necessary:
 
@@ -550,7 +550,7 @@ try {
 }
 ```
 
-Under the hood, [verror](https://npmjs.com/package/verror) is being used to wrap errors.
+Under the hood, [verror](https://npmjs.com/package/verror) is used to wrap errors.
 
 ### CLI
 

--- a/README.md
+++ b/README.md
@@ -532,6 +532,26 @@ The [`FileLocker` class](./src/file-locker.ts) uses `beforeAll` and `afterAll` t
 
 All events are type-safe, so IDEs will prevent typos and supply strong types for the event payloads.
 
+### Errors
+
+When a migration throws an error, it will be wrapped in a `MigrationError` which captures the migration metadata (name, path etc.) as well as the original error message, and _will be rethrown_. In most cases, this is exppected behaviour, and doesn't require any special handling beyond standard error logging setups.
+
+If you expect failures and want to try to recover from them, you will need to try-catch the call to `umzug.up()`. You can access the original error from the `.cause` property if necessary:
+
+```js
+try {
+  await umzug.up();
+} catch (e) {
+  if (e instanceof MigrationError) {
+    const original = e.cause;
+    // do something with the original error here
+  }
+  throw e;
+}
+```
+
+Under the hood, [verror](https://npmjs.com/package/verror) is being used to wrap errors.
+
 ### CLI
 
 🚧🚧🚧 The CLI is new to Umzug v3 beta and is not yet stable. Feedback on it is welcome in [discussions](https://github.com/sequelize/umzug/discussions) 🚧🚧🚧

--- a/package-lock.json
+++ b/package-lock.json
@@ -1009,6 +1009,11 @@
 			"integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
 			"dev": true
 		},
+		"@types/verror": {
+			"version": "1.10.4",
+			"resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.4.tgz",
+			"integrity": "sha512-OjJdqx6QlbyZw9LShPwRW+Kmiegeg3eWNI41MQQKaG3vjdU2L9SRElntM51HmHBY1cu7izxQJ1lMYioQh3XMBg=="
+		},
 		"@types/yargs": {
 			"version": "15.0.4",
 			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
@@ -1556,8 +1561,7 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
@@ -2304,8 +2308,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
 			"version": "7.0.0",
@@ -3637,8 +3640,7 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
 			"version": "3.1.1",
@@ -9533,7 +9535,6 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
 	],
 	"dependencies": {
 		"@rushstack/ts-command-line": "~4.7.7",
+		"@types/verror": "^1.10.4",
 		"emittery": "~0.7.2",
 		"fs-jetpack": "~4.0.0",
 		"glob": "~7.1.6",
-		"type-fest": "~0.19.0"
+		"type-fest": "~0.19.0",
+		"verror": "^1.10.0"
 	},
 	"devDependencies": {
 		"@types/jest": "26.0.16",

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -18,7 +18,7 @@ import {
 	UmzugEvents,
 	UmzugOptions,
 } from './types';
-import * as verror from 'verror';
+import * as VError from 'verror';
 
 const globAsync = promisify(glob);
 
@@ -26,17 +26,17 @@ interface MigrationErrorParams extends MigrationParams<unknown> {
 	direction: 'up' | 'down';
 }
 
-export class Rethrowable extends verror.VError {
-	static wrap(throwable: unknown): verror {
-		if (throwable instanceof verror.VError) {
+export class Rethrowable extends VError {
+	static wrap(throwable: unknown): VError {
+		if (throwable instanceof VError) {
 			return throwable;
 		}
 
 		if (throwable instanceof Error) {
-			return new verror.VError(throwable, 'Original error');
+			return new VError(throwable, 'Original error');
 		}
 
-		return new verror.VError(
+		return new VError(
 			{
 				info: { original: throwable },
 			},
@@ -49,7 +49,7 @@ export class Rethrowable extends verror.VError {
 		throw Rethrowable.wrap(original);
 	}
 }
-export class MigrationError extends verror.VError {
+export class MigrationError extends VError {
 	constructor(migration: MigrationErrorParams, original: unknown) {
 		super(
 			{

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -6,6 +6,7 @@ import * as templates from './templates';
 import * as glob from 'glob';
 import { UmzugCLI } from './cli';
 import * as emittery from 'emittery';
+import * as VError from 'verror';
 import {
 	MigrateDownOptions,
 	MigrateUpOptions,
@@ -18,7 +19,6 @@ import {
 	UmzugEvents,
 	UmzugOptions,
 } from './types';
-import * as VError from 'verror';
 
 const globAsync = promisify(glob);
 
@@ -44,11 +44,8 @@ export class Rethrowable extends VError {
 			throwable
 		);
 	}
-
-	static rethrow(original: unknown): never {
-		throw Rethrowable.wrap(original);
-	}
 }
+
 export class MigrationError extends VError {
 	constructor(migration: MigrationErrorParams, original: unknown) {
 		super(
@@ -57,14 +54,10 @@ export class MigrationError extends VError {
 				name: 'MigrationError',
 				info: migration,
 			},
-			'%s migration %s failed',
-			migration.direction,
-			migration.name
+			'Migration %s (%s) failed',
+			migration.name,
+			migration.direction
 		);
-	}
-
-	static rethrow(migration: MigrationErrorParams): (original: unknown) => never {
-		return original => Rethrowable.rethrow(new MigrationError(migration, original));
 	}
 }
 

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -391,11 +391,11 @@ describe('alternate migration inputs', () => {
 		});
 
 		await expect(umzug.up()).rejects.toThrowErrorMatchingInlineSnapshot(
-			`"up migration m2 failed: Original error: Some cryptic failure"`
+			`"Migration m2 (up) failed: Original error: Some cryptic failure"`
 		);
 
 		await expect(umzug.down()).rejects.toThrowErrorMatchingInlineSnapshot(
-			`"down migration m1 failed: Original error: Some cryptic failure"`
+			`"Migration m1 (down) failed: Original error: Some cryptic failure"`
 		);
 	});
 
@@ -417,7 +417,7 @@ describe('alternate migration inputs', () => {
 		});
 
 		await expect(umzug.up()).rejects.toThrowErrorMatchingInlineSnapshot(
-			`"up migration m2 failed: Some cryptic failure"`
+			`"Migration m2 (up) failed: Some cryptic failure"`
 		);
 
 		// slightly weird format verror uses, not worth validating much more than that the `cause` is captured
@@ -428,7 +428,7 @@ describe('alternate migration inputs', () => {
 		});
 
 		await expect(umzug.down()).rejects.toThrowErrorMatchingInlineSnapshot(
-			`"down migration m1 failed: Some cryptic failure"`
+			`"Migration m1 (down) failed: Some cryptic failure"`
 		);
 
 		await expect(umzug.down()).rejects.toMatchObject({
@@ -459,11 +459,11 @@ describe('alternate migration inputs', () => {
 		});
 
 		await expect(umzug.up()).rejects.toThrowErrorMatchingInlineSnapshot(
-			`"up migration m2 failed: Non-error value thrown. See info for full props: Some cryptic failure"`
+			`"Migration m2 (up) failed: Non-error value thrown. See info for full props: Some cryptic failure"`
 		);
 
 		await expect(umzug.down()).rejects.toThrowErrorMatchingInlineSnapshot(
-			`"down migration m1 failed: Non-error value thrown. See info for full props: Some cryptic failure"`
+			`"Migration m1 (down) failed: Non-error value thrown. See info for full props: Some cryptic failure"`
 		);
 	});
 
@@ -488,7 +488,7 @@ describe('alternate migration inputs', () => {
 		expect([names(await umzug.pending()), names(await umzug.executed())]).toEqual([['m2.ts'], ['m1.ts']]);
 
 		await expect(umzug.up()).rejects.toThrowErrorMatchingInlineSnapshot(`
-			"up migration m2.ts failed: Original error: Fake syntax error to simulate typescript modules not being registered
+			"Migration m2.ts (up) failed: Original error: Fake syntax error to simulate typescript modules not being registered
 
 			TypeScript files can be required by adding \`ts-node\` as a dependency and calling \`require('ts-node/register')\` at the program entrypoint before running migrations."
 		`);


### PR DESCRIPTION
This makes error messages much more helpful, especially when custom resolvers are used which do things like execute SQL directly.

Instead of `syntax error near ';'` users will see `up migration 2000-01-01T12-00.foobar.sql failed: syntax error near ';'`

[verror](https://npmjs.com/package/verror) is pretty widely used so seems appropriate over rolling our own error-wrapping logic. It hasn't had an update in a while though which isn't ideal. @papb if you're aware of another library that's a little more active and does roughly the same thing, I'm all ears.