### PR TITLE
Create context per run

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,8 +525,8 @@ Umzug is an [emittery event emitter](https://www.npmjs.com/package/emittery). Ea
 
 These events run at the beginning and end of `up` and `down` calls. They'll receive an object containing a `context` property:
 
-- `beforeAll` - Before any of the migrations are run.
-- `afterAll` - After all the migrations have been executed. Note: this will always run, even if migrations throw an error.
+- `beforeCommand` - Before any command (`'up' | 'down' | 'executed' | 'pending'`) is run.
+- `afterCommand` - After any command (`'up' | 'down' | 'executed' | 'pending'`) is run. Note: this will always run, even if the command throws an error.
 
 The [`FileLocker` class](./src/file-locker.ts) uses `beforeAll` and `afterAll` to implement a simple filesystem-based locking mechanism.
 

--- a/src/file-locker.ts
+++ b/src/file-locker.ts
@@ -47,10 +47,10 @@ export class FileLocker {
 		locker.attachTo(umzug);
 	}
 
-	/** Attach `beforeAll` and `afterAll` events to an umzug instance */
+	/** Attach lock handlers to `beforeCommand` and `afterCommand` events on an umzug instance */
 	attachTo(umzug: Umzug): void {
-		umzug.on('beforeAll', async () => this.getLock());
-		umzug.on('afterAll', async () => this.releaseLock());
+		umzug.on('beforeCommand', async () => this.getLock());
+		umzug.on('afterCommand', async () => this.releaseLock());
 	}
 
 	private async readFile(filepath: string): Promise<string | undefined> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type Promisable<T> = T | PromiseLike<T>;
 export type LogFn = (message: Record<string, unknown>) => void;
 
 /** Constructor options for the Umzug class */
-export interface UmzugOptions<Ctx = unknown> {
+export interface UmzugOptions<Ctx extends Record<string, unknown> = Record<string, unknown>> {
 	/** The migrations that the Umzug instance should perform */
 	migrations: InputMigrations<Ctx>;
 	/** A logging function. Pass `console` to use stdout, or pass in your own logger. Pass `undefined` explicitly to disable logging. */
@@ -20,7 +20,7 @@ export interface UmzugOptions<Ctx = unknown> {
 	/** The storage implementation. By default, `JSONStorage` will be used */
 	storage?: UmzugStorage<Ctx>;
 	/** An optional context object, which will be passed to each migration function, if defined */
-	context?: Ctx;
+	context?: Ctx | (() => Ctx);
 	/** Options for file creation */
 	create?: {
 		/**
@@ -83,7 +83,7 @@ export type GlobInputMigrations<T> = {
 export type InputMigrations<T> =
 	| GlobInputMigrations<T>
 	| Array<RunnableMigration<T>>
-	| ((context: T) => Promisable<Array<RunnableMigration<T>>>);
+	| ((context: T) => Promisable<InputMigrations<T>>);
 
 /** A function which takes a migration name, path and context, and returns an object with `up` and `down` functions. */
 export type Resolver<T> = (params: MigrationParams<T>) => RunnableMigration<T>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type Promisable<T> = T | PromiseLike<T>;
 export type LogFn = (message: Record<string, unknown>) => void;
 
 /** Constructor options for the Umzug class */
-export interface UmzugOptions<Ctx extends Record<string, unknown> = Record<string, unknown>> {
+export interface UmzugOptions<Ctx extends {} = Record<string, unknown>> {
 	/** The migrations that the Umzug instance should perform */
 	migrations: InputMigrations<Ctx>;
 	/** A logging function. Pass `console` to use stdout, or pass in your own logger. Pass `undefined` explicitly to disable logging. */
@@ -144,6 +144,6 @@ export interface UmzugEvents<Ctx> {
 	migrated: MigrationParams<Ctx>;
 	reverting: MigrationParams<Ctx>;
 	reverted: MigrationParams<Ctx>;
-	beforeAll: { context: Ctx };
-	afterAll: { context: Ctx };
+	beforeCommand: { command: string; context: Ctx };
+	afterCommand: { command: string; context: Ctx };
 }

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -608,10 +608,12 @@ describe('alternate migration inputs', () => {
 		expect(spy).toHaveBeenNthCalledWith(1, {
 			name: 'm1.sql',
 			path: path.join(syncer.baseDir, 'directory1/m1.sql'),
+			context: {},
 		});
 		expect(spy).toHaveBeenNthCalledWith(2, {
 			name: 'm2.sql',
 			path: path.join(syncer.baseDir, 'deeply/nested/directory2/m2.sql'),
+			context: {},
 		});
 	});
 });


### PR DESCRIPTION
This adds a "lazy" option to the `context` and `migrations` options, which allows for:

1) more customisation in child classes
2) it's a less dangerous flow if two call sites try to call `up` at the same time and do things like mutating `context`, which in theory is possible now

Breaking change to the `beta` tag: `beforeAll`/`afterAll` are replaced by `beforeCommand`/`afterCommand`, which also run on `executed` and `pending` commands too now. For hooks that should only run before migrations are applied/reverted, use:

```js
umzug.on('beforeCommand', ev => {
  if (ev.command !== 'up' && ev.command !== 'down') {
    return
  }
  // ...whatever you were doing in beforeAll/afterAll before
})
```

Easiest to view with https://github.com/sequelize/umzug/pull/419/files?w=1