### PR TITLE
Breaking change (to storages): remove string parameter

### DIFF
--- a/examples/3.raw-sql/umzug.ts
+++ b/examples/3.raw-sql/umzug.ts
@@ -35,10 +35,10 @@ export const migrator = new Umzug({
 			const [results] = await client.query(`select name from my_migrations_table`);
 			return results.map((r: { name: string }) => r.name);
 		},
-		async logMigration(name, { context: client }) {
+		async logMigration({ name, context: client }) {
 			await client.query(`insert into my_migrations_table(name) values ($1)`, [name]);
 		},
-		async unlogMigration(name, { context: client }) {
+		async unlogMigration({ name, context: client }) {
 			await client.query(`delete from my_migrations_table where name = $1`, [name]);
 		},
 	},

--- a/src/storage/contract.ts
+++ b/src/storage/contract.ts
@@ -4,12 +4,12 @@ export interface UmzugStorage<Ctx = unknown> {
 	/**
 	 * Logs migration to be considered as executed.
 	 */
-	logMigration: (migrationName: string, params: MigrationParams<Ctx>) => Promise<void>;
+	logMigration: (params: MigrationParams<Ctx>) => Promise<void>;
 
 	/**
 	 * Unlogs migration (makes it to be considered as pending).
 	 */
-	unlogMigration: (migrationName: string, params: MigrationParams<Ctx>) => Promise<void>;
+	unlogMigration: (params: MigrationParams<Ctx>) => Promise<void>;
 
 	/**
 	 * Gets list of executed migrations.

--- a/src/storage/json.ts
+++ b/src/storage/json.ts
@@ -17,14 +17,14 @@ export class JSONStorage implements UmzugStorage {
 		this.path = options?.path ?? jetpack.path(process.cwd(), 'umzug.json');
 	}
 
-	async logMigration(migrationName: string): Promise<void> {
+	async logMigration({ name: migrationName }: { name: string }): Promise<void> {
 		const loggedMigrations = await this.executed();
 		loggedMigrations.push(migrationName);
 
 		await jetpack.writeAsync(this.path, JSON.stringify(loggedMigrations, null, 2));
 	}
 
-	async unlogMigration(migrationName: string): Promise<void> {
+	async unlogMigration({ name: migrationName }: { name: string }): Promise<void> {
 		const loggedMigrations = await this.executed();
 		const updatedMigrations = loggedMigrations.filter(name => name !== migrationName);
 

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -3,10 +3,10 @@ import { UmzugStorage } from './contract';
 export const memoryStorage = (): UmzugStorage => {
 	let executed: string[] = [];
 	return {
-		logMigration: async name => {
+		logMigration: async ({ name }) => {
 			executed.push(name);
 		},
-		unlogMigration: async name => {
+		unlogMigration: async ({ name }) => {
 			executed = executed.filter(n => n !== name);
 		},
 		executed: async () => executed.slice(),

--- a/src/storage/mongodb.ts
+++ b/src/storage/mongodb.ts
@@ -49,11 +49,11 @@ export class MongoDBStorage implements UmzugStorage {
 		this.collectionName = (options as any).collectionName ?? 'migrations'; // TODO remove this
 	}
 
-	async logMigration(migrationName: string): Promise<void> {
+	async logMigration({ name: migrationName }: { name: string }): Promise<void> {
 		await this.collection.insertOne({ migrationName });
 	}
 
-	async unlogMigration(migrationName: string): Promise<void> {
+	async unlogMigration({ name: migrationName }: { name: string }): Promise<void> {
 		await this.collection.removeOne({ migrationName });
 	}
 

--- a/src/storage/sequelize.ts
+++ b/src/storage/sequelize.ts
@@ -146,14 +146,14 @@ export class SequelizeStorage implements UmzugStorage {
 		) as ModelClassType;
 	}
 
-	async logMigration(migrationName: string): Promise<void> {
+	async logMigration({ name: migrationName }: { name: string }): Promise<void> {
 		await this.model.sync();
 		await this.model.create({
 			[this.columnName]: migrationName,
 		});
 	}
 
-	async unlogMigration(migrationName: string): Promise<void> {
+	async unlogMigration({ name: migrationName }: { name: string }): Promise<void> {
 		await this.model.sync();
 		await this.model.destroy({
 			where: {

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -288,7 +288,7 @@ export class Umzug<Ctx extends object = object> extends emittery.Typed<UmzugEven
 					throw new MigrationError({ direction: 'up', ...params }, e);
 				}
 
-				await this.storage.logMigration(m.name, params);
+				await this.storage.logMigration(params);
 
 				const duration = (Date.now() - start) / 1000;
 				this.logging({ event: 'migrated', name: m.name, durationSeconds: duration });
@@ -348,7 +348,7 @@ export class Umzug<Ctx extends object = object> extends emittery.Typed<UmzugEven
 					throw new MigrationError({ direction: 'down', ...params }, e);
 				}
 
-				await this.storage.unlogMigration(m.name, params);
+				await this.storage.unlogMigration(params);
 
 				const duration = Number.parseFloat(((Date.now() - start) / 1000).toFixed(3));
 				this.logging({ event: 'reverted', name: m.name, durationSeconds: duration });

--- a/test/storage/json.test.ts
+++ b/test/storage/json.test.ts
@@ -29,15 +29,15 @@ describe('JSONStorage', () => {
 		const storage = new JSONStorage({ path: path.join(syncer.baseDir, 'umzug.json') });
 
 		test('adds entry', async () => {
-			await storage.logMigration('m1.txt');
+			await storage.logMigration({ name: 'm1.txt' });
 
 			expect(syncer.read()).toEqual({
 				'umzug.json': json(['m1.txt']),
 			});
 		});
 		test(`doesn't dedupe`, async () => {
-			await storage.logMigration('m1.txt');
-			await storage.logMigration('m1.txt');
+			await storage.logMigration({ name: 'm1.txt' });
+			await storage.logMigration({ name: 'm1.txt' });
 
 			expect(syncer.read()).toEqual({
 				'umzug.json': json(['m1.txt', 'm1.txt']),
@@ -53,14 +53,14 @@ describe('JSONStorage', () => {
 		const storage = new JSONStorage({ path: path.join(syncer.baseDir, 'umzug.json') });
 
 		test('removes entry', async () => {
-			await storage.unlogMigration('m1.txt');
+			await storage.unlogMigration({ name: 'm1.txt' });
 			expect(syncer.read()).toEqual({
 				'umzug.json': '[]',
 			});
 		});
 
 		test('does nothing when unlogging non-existent migration', async () => {
-			await storage.unlogMigration('does-not-exist.txt');
+			await storage.unlogMigration({ name: 'does-not-exist.txt' });
 
 			expect(syncer.read()).toEqual({
 				'umzug.json': json(['m1.txt']),
@@ -79,7 +79,7 @@ describe('JSONStorage', () => {
 		});
 
 		test('returns logged migration', async () => {
-			await storage.logMigration('m1.txt');
+			await storage.logMigration({ name: 'm1.txt' });
 			expect(await storage.executed()).toEqual(['m1.txt']);
 		});
 	});

--- a/test/storage/memory.test.ts
+++ b/test/storage/memory.test.ts
@@ -16,17 +16,17 @@ describe('memoryStorage', () => {
 	test('logMigration, executed and unlogMigration', async () => {
 		const storage = memoryStorage();
 
-		await storage.logMigration('m1', { name: 'm1', context: {} });
+		await storage.logMigration({ name: 'm1', context: {} });
 		expect(await storage.executed({ context: {} })).toEqual(['m1']);
 
-		await storage.logMigration('m1', { name: 'm1', context: {} });
-		await storage.logMigration('m2', { name: 'm1', context: {} });
+		await storage.logMigration({ name: 'm1', context: {} });
+		await storage.logMigration({ name: 'm2', context: {} });
 		expect(await storage.executed({ context: {} })).toEqual(['m1', 'm1', 'm2']);
 
-		await storage.unlogMigration('m1', { name: 'm1', context: {} });
+		await storage.unlogMigration({ name: 'm1', context: {} });
 		expect(await storage.executed({ context: {} })).toEqual(['m2']);
 
-		await storage.unlogMigration('m2', { name: 'm1', context: {} });
+		await storage.unlogMigration({ name: 'm2', context: {} });
 		expect(await storage.executed({ context: {} })).toEqual([]);
 	});
 

--- a/test/storage/mongodb.test.ts
+++ b/test/storage/mongodb.test.ts
@@ -69,7 +69,7 @@ describe('MongoDBStorage', () => {
 	describe('logMigration', () => {
 		test('adds entry to storage', async () => {
 			const storage = new MongoDBStorage({ collection: mockCollection });
-			await storage.logMigration('m1.txt');
+			await storage.logMigration({ name: 'm1.txt' });
 			expect(mockCollection.insertOne).toHaveBeenCalledTimes(1);
 			expect(mockCollection.insertOne).toHaveBeenCalledWith({
 				migrationName: 'm1.txt',
@@ -80,7 +80,7 @@ describe('MongoDBStorage', () => {
 	describe('unlogMigration', () => {
 		test('adds entry to storage', async () => {
 			const storage = new MongoDBStorage({ collection: mockCollection });
-			await storage.unlogMigration('m1.txt');
+			await storage.unlogMigration({ name: 'm1.txt' });
 			expect(mockCollection.removeOne).toHaveBeenCalledTimes(1);
 			expect(mockCollection.removeOne).toHaveBeenCalledWith({
 				migrationName: 'm1.txt',

--- a/test/storage/sequelize.test.ts
+++ b/test/storage/sequelize.test.ts
@@ -205,7 +205,7 @@ describe('sequelize', () => {
 				.then((allTables: any) => {
 					expect(Object.keys(allTables)).toHaveLength(0);
 				})
-				.then(() => storage.logMigration('asd.js'))
+				.then(() => storage.logMigration({ name: 'asd.js' }))
 				.then(() => storage.model.sequelize!.getQueryInterface().showAllTables())
 				.then((allTables: any) => {
 					expect(allTables).toEqual(['SequelizeMeta']);
@@ -218,7 +218,7 @@ describe('sequelize', () => {
 			});
 
 			return storage
-				.logMigration('asd.js')
+				.logMigration({ name: 'asd.js' })
 				.then(() => storage.model.findAll())
 				.then(migrations => {
 					expect(migrations.length).toBe(1);
@@ -233,7 +233,7 @@ describe('sequelize', () => {
 			});
 
 			return storage
-				.logMigration('asd.js')
+				.logMigration({ name: 'asd.js' })
 				.then(() => storage.model.findAll())
 				.then(migrations => {
 					expect(migrations.length).toBe(1);
@@ -256,7 +256,7 @@ describe('sequelize', () => {
 			const startTime = new Date(Math.floor(Date.now() / 1000) * 1000);
 
 			return storage
-				.logMigration('asd.js')
+				.logMigration({ name: 'asd.js' })
 				.then(() => storage.model.findAll())
 				.then(migrations => {
 					expect(migrations.length).toBe(1);
@@ -277,7 +277,7 @@ describe('sequelize', () => {
 				.then((allTables: any) => {
 					expect(Object.keys(allTables)).toHaveLength(0);
 				})
-				.then(() => storage.unlogMigration('asd.js'))
+				.then(() => storage.unlogMigration({ name: 'asd.js' }))
 				.then(() => storage.model.sequelize!.getQueryInterface().showAllTables())
 				.then((allTables: any) => {
 					expect(allTables).toEqual(['SequelizeMeta']);
@@ -288,12 +288,12 @@ describe('sequelize', () => {
 			const storage = new Storage({ sequelize: helper.sequelize });
 
 			return storage
-				.logMigration('asd.js')
+				.logMigration({ name: 'asd.js' })
 				.then(() => storage.model.findAll())
 				.then(migrations => {
 					expect(migrations.length).toBe(1);
 				})
-				.then(() => storage.unlogMigration('asd.js'))
+				.then(() => storage.unlogMigration({ name: 'asd.js' }))
 				.then(() => storage.model.findAll())
 				.then(migrations => {
 					expect(Object.keys(migrations)).toHaveLength(0);
@@ -304,9 +304,9 @@ describe('sequelize', () => {
 			const storage = new Storage({ sequelize: helper.sequelize });
 
 			return storage
-				.logMigration('migration1.js')
-				.then(() => storage.logMigration('migration2.js'))
-				.then(() => storage.unlogMigration('migration2.js'))
+				.logMigration({ name: 'migration1.js' })
+				.then(() => storage.logMigration({ name: 'migration2.js' }))
+				.then(() => storage.unlogMigration({ name: 'migration2.js' }))
 				.then(() => storage._model().findAll())
 				.then(migrations => {
 					expect(migrations.length).toBe(1);
@@ -321,12 +321,12 @@ describe('sequelize', () => {
 			});
 
 			return storage
-				.logMigration('asd.js')
+				.logMigration({ name: 'asd.js' })
 				.then(() => storage.model.findAll())
 				.then(migrations => {
 					expect(migrations.length).toBe(1);
 				})
-				.then(() => storage.unlogMigration('asd.js'))
+				.then(() => storage.unlogMigration({ name: 'asd.js' }))
 				.then(() => storage.model.findAll())
 				.then(migrations => {
 					expect(Object.keys(migrations)).toHaveLength(0);
@@ -340,12 +340,12 @@ describe('sequelize', () => {
 			});
 
 			return storage
-				.logMigration('asd.js')
+				.logMigration({ name: 'asd.js' })
 				.then(() => storage.model.findAll())
 				.then(migrations => {
 					expect(migrations.length).toBe(1);
 				})
-				.then(() => storage.unlogMigration('asd.js'))
+				.then(() => storage.unlogMigration({ name: 'asd.js' }))
 				.then(() => storage.model.findAll())
 				.then(migrations => {
 					expect(Object.keys(migrations)).toHaveLength(0);
@@ -398,7 +398,7 @@ describe('sequelize', () => {
 			});
 
 			return storage
-				.logMigration('asd.js')
+				.logMigration({ name: 'asd.js' })
 				.then(() => storage.executed())
 				.then(migrations => {
 					expect(migrations).toEqual(['asd.js']);
@@ -412,7 +412,7 @@ describe('sequelize', () => {
 			});
 
 			return storage
-				.logMigration('asd.js')
+				.logMigration({ name: 'asd.js' })
 				.then(() => storage.executed())
 				.then(migrations => {
 					expect(migrations).toEqual(['asd.js']);
@@ -426,7 +426,7 @@ describe('sequelize', () => {
 			});
 
 			return storage
-				.logMigration('asd.js')
+				.logMigration({ name: 'asd.js' })
 				.then(() => storage.executed())
 				.then(migrations => {
 					expect(migrations).toEqual(['asd.js']);

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -351,7 +351,7 @@ describe('alternate migration inputs', () => {
 
 		expect(spy.mock.calls).toEqual([
 			['executed', { context: { someCustomSqlClient: {} } }],
-			['logMigration', 'm1', { name: 'm1', context: { someCustomSqlClient: {} } }],
+			['logMigration', { name: 'm1', context: { someCustomSqlClient: {} } }],
 		]);
 
 		spy.mockClear();
@@ -361,7 +361,7 @@ describe('alternate migration inputs', () => {
 
 		expect(spy.mock.calls).toEqual([
 			['executed', { context: { someCustomSqlClient: {} } }],
-			['unlogMigration', 'm1', { name: 'm1', context: { someCustomSqlClient: {} } }],
+			['unlogMigration', { name: 'm1', context: { someCustomSqlClient: {} } }],
 		]);
 	});
 


### PR DESCRIPTION
This removes the now-redundant `name` parameter from the logMigration and unlogMigration methods in UmzugStorage. This requires an update to storage implementations.

This is the breaking chanage discussed in https://github.com/sequelize/umzug/pull/398