### PR TITLE
Add prod tsconfig for lib output

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
 	parserOptions: {
 		ecmaVersion: 2018,
 		sourceType: 'module',
-		project: ['./tsconfig.eslint.json'],
+		project: ['./tsconfig.json'],
 		extraFileExtensions: ['.md', '.mjs'],
 	},
 	plugins: ['@typescript-eslint/eslint-plugin', 'prettier', 'unicorn', 'jest', 'import', 'codegen'],

--- a/examples/3.raw-sql/umzug.ts
+++ b/examples/3.raw-sql/umzug.ts
@@ -19,11 +19,11 @@ export const migrator = new Umzug({
 	migrations: {
 		glob: ['migrations/*.sql', { cwd: __dirname }],
 		resolve: params => {
-			const downPath = path.join(path.dirname(params.path), 'down', path.basename(params.path));
+			const downPath = path.join(path.dirname(params.path!), 'down', path.basename(params.path!));
 			return {
 				name: params.name,
 				path: params.path,
-				up: async () => params.context.query(fs.readFileSync(params.path).toString()),
+				up: async () => params.context.query(fs.readFileSync(params.path!).toString()),
 				down: async () => params.context.query(fs.readFileSync(downPath).toString()),
 			};
 		},

--- a/examples/6.events/umzug.ts
+++ b/examples/6.events/umzug.ts
@@ -24,11 +24,11 @@ const fakeApi = {
 	},
 };
 
-migrator.on('beforeAll', async () => {
+migrator.on('beforeCommand', async () => {
 	await fakeApi.shutdownInternalService();
 });
 
-migrator.on('afterAll', async () => {
+migrator.on('afterCommand', async () => {
 	await fakeApi.restartInternalService();
 });
 

--- a/package.json
+++ b/package.json
@@ -55,12 +55,14 @@
 		"uuid": "8.3.2"
 	},
 	"scripts": {
-		"build": "del-cli lib && tsc",
-		"lint": "eslint --ext .js,.ts,.md . --max-warnings 0",
+		"build": "del-cli lib && tsc -p tsconfig.lib.json",
+		"eslint": "eslint --ext .js,.ts,.md . --max-warnings 0",
+		"lint": "npm run type-check && npm run eslint",
 		"prepare": "npm run build",
 		"release": "np --no-yarn --no-2fa",
 		"pretest": "del-cli test/generated",
-		"test": "jest"
+		"test": "jest",
+		"type-check": "tsc -p ."
 	},
 	"repository": {
 		"type": "git",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,8 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"include": ["*", "**/*", ".*.js", "*.md"],
-	"compilerOptions": {
-		"noEmit": true,
-		"allowJs": true
-	}
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
-	"include": [
-		"src"
-	],
 	"compilerOptions": {
+		"noEmit": true,
+		"allowJs": true,
 		"outDir": "lib",
 		"target": "es2018",
 		"module": "commonjs",
@@ -20,5 +19,16 @@
 		"noFallthroughCasesInSwitch": true,
 		"noEmitOnError": true,
 		"skipLibCheck": true
-	}
+	},
+	"include": [
+		"src",
+		"test",
+		"examples",
+		"*.md",
+		"*.js",
+		".*.js"
+	],
+	"exclude": [
+		"test/generated"
+	]
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		"src"
+	],
+	"compilerOptions": {
+		"noEmit": false
+	}
+}


### PR DESCRIPTION
@papb this is a pattern I've found useful in a few projects now.

- Have a `tsconfig.json` which includes _all_ source code but has `noEmit: true` so is only used for checking
- Have a `tsconfig.lib.json` which only includes `src`, and extends `tsconfig.json` with `noEmit: false`. This is used to produce the actual library output.
- `tsc -p tsconfig.json` is part of the _lint_ step. It makes sure all the code in the project is ok. `src`, `test`, `examples` etc.
- `tsc -p tsconfig.lib.json` is the _build_ step.

The benefits are:

- All type errors are caught by `npm run lint`. Here's an example from another PR of a change I had to just remember about since it wasn't flagged by CI (the file is under `examples/*`, which wasn't included in `tsconfig.json`: https://github.com/sequelize/umzug/pull/429/commits/435f968a142ef49a7bc7e3e5a4753a6b91d908b6 
- IDEs pick up the correct settings. By default VSCode (and others, I believe), search for a `tsconfig.json` for settings for typescript hints/red squigglies. One example: this project has `strictNullChecks: true`, but since tsconfig.json was ignoring `test`, VSCode wasn't showing null errors. ts-jest still caught them, but it's better DX if the IDE knows what's going on. 