### PR TITLE
Support tsconfigs with esModuleInterop

### DIFF
--- a/examples/3.raw-sql/umzug.ts
+++ b/examples/3.raw-sql/umzug.ts
@@ -1,7 +1,7 @@
 import { Umzug } from 'umzug';
 import { Sequelize } from 'sequelize';
-import * as path from 'path';
-import * as fs from 'fs';
+import path = require('path');
+import fs = require('fs');
 
 const getRawSqlClient = () => {
 	// this implementation happens to use sequelize, but you may want to use a specialised sql client

--- a/examples/5.custom-template/umzug.ts
+++ b/examples/5.custom-template/umzug.ts
@@ -1,7 +1,7 @@
 import { Umzug, SequelizeStorage } from 'umzug';
 import { Sequelize } from 'sequelize';
-import * as fs from 'fs';
-import * as path from 'path';
+import fs = require('fs');
+import path = require('path');
 
 const sequelize = new Sequelize({
 	dialect: 'sqlite',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import * as cli from '@rushstack/ts-command-line';
+import cli = require('@rushstack/ts-command-line');
 import type { MigrateDownOptions, MigrateUpOptions } from './types';
 import { Umzug } from './umzug';
 

--- a/src/file-locker.ts
+++ b/src/file-locker.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import fs = require('fs');
+import path = require('path');
 import { Umzug } from './umzug';
 
 export interface FileLockerOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { UmzugStorage } from './storage';
-import * as typeFest from 'type-fest';
+import typeFest = require('type-fest');
 
 /**
  * Create a type that has mutually exclusive keys.

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -1,12 +1,13 @@
-import * as path from 'path';
-import * as fs from 'fs';
+import path = require('path');
+import fs = require('fs');
 import { promisify } from 'util';
 import { UmzugStorage, JSONStorage, verifyUmzugStorage } from './storage';
-import * as templates from './templates';
-import * as glob from 'glob';
+import templates = require('./templates');
+import glob = require('glob');
 import { CommandLineParserOptions, UmzugCLI } from './cli';
-import * as emittery from 'emittery';
-import * as VError from 'verror';
+import emittery = require('emittery');
+import VError = require('verror');
+
 import {
 	InputMigrations,
 	MigrateDownOptions,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,10 +1,10 @@
 import { fsSyncer } from 'fs-syncer';
 import { UmzugCLI } from '../src/cli';
-import * as path from 'path';
-import * as fs from 'fs';
-import * as childProcess from 'child_process';
+import path = require('path');
+import fs = require('fs');
+import childProcess = require('child_process');
 import { Umzug } from '../src';
-import * as del from 'del';
+import del = require('del');
 import { expectTypeOf } from 'expect-type';
 
 describe('cli from instance', () => {

--- a/test/lock.test.ts
+++ b/test/lock.test.ts
@@ -1,7 +1,7 @@
 import { JSONStorage, FileLocker, Umzug } from '../src';
-import * as path from 'path';
+import path = require('path');
 import { fsSyncer } from 'fs-syncer';
-import * as pEvent from 'p-event';
+import pEvent = require('p-event');
 
 const names = (migrations: Array<{ name: string }>) => migrations.map(m => m.name);
 const delay = async (ms: number) => new Promise(r => setTimeout(r, ms));

--- a/test/sequelize.test.ts
+++ b/test/sequelize.test.ts
@@ -2,7 +2,7 @@ import { Sequelize, QueryInterface } from 'sequelize';
 import { SequelizeStorage } from '../src';
 import { Umzug } from '../src/umzug';
 import { fsSyncer } from 'fs-syncer';
-import * as _path from 'path';
+import _path = require('path');
 
 describe('recommended usage', () => {
 	const baseDir = _path.join(__dirname, 'generated/sequelize/integration/recommended-usage');

--- a/test/storage/json.test.ts
+++ b/test/storage/json.test.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from 'expect-type';
 import { JSONStorage, UmzugStorage } from '../../src';
 import { fsSyncer } from 'fs-syncer';
-import * as path from 'path';
+import path = require('path');
 
 describe('JSONStorage', () => {
 	describe('constructor', () => {

--- a/test/storage/sequelize.test.ts
+++ b/test/storage/sequelize.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/promise-function-async */
 import { SequelizeStorage as Storage } from '../../src';
 
-import * as sequelize from 'sequelize';
-import * as path from 'path';
+import sequelize = require('sequelize');
+import path = require('path');
 import { v4 as uuid } from 'uuid';
 import jetpack = require('fs-jetpack');
 

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -1,8 +1,8 @@
 import { memoryStorage, RerunBehavior, Umzug } from '../src';
-import * as path from 'path';
+import path = require('path');
 import { fsSyncer } from 'fs-syncer';
 import { expectTypeOf } from 'expect-type';
-import * as VError from 'verror';
+import VError = require('verror');
 
 jest.mock('../src/storage', () => {
 	const storage = jest.requireActual('../src/storage');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
 		"noUnusedParameters": false,
 		"noFallthroughCasesInSwitch": true,
 		"noEmitOnError": true,
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"esModuleInterop": true
 	},
 	"include": [
 		"src",


### PR DESCRIPTION
Fixes #434 

@papb I remember you suggested using the `import foo = require('foo')` syntax all along!

I'm still not sure this is the ideal solution, but it works and it's clear how it corresponds to `const foo = require('foo')` in the compiled js.

CommonJS vs ES modules is still v confusing to me, but probably setting `"type": "module"` in package.json would make sense at some point: https://redfin.engineering/node-modules-at-war-why-commonjs-and-es-modules-cant-get-along-9617135eeca1