### PR TITLE
Add ability to retrieve context asynchronously before the migrations run

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export interface UmzugOptions<Ctx extends {} = Record<string, unknown>> {
 	/** The storage implementation. By default, `JSONStorage` will be used */
 	storage?: UmzugStorage<Ctx>;
 	/** An optional context object, which will be passed to each migration function, if defined */
-	context?: Ctx | (() => Ctx);
+	context?: Ctx | (() => Promise<Ctx> | Ctx);
 	/** Options for file creation */
 	create?: {
 		/**

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -481,11 +481,6 @@ export class Umzug<Ctx extends object = object> extends emittery<UmzugEvents<Ctx
 	}
 
 	private async getContext(): Promise<Ctx> {
-		const isAsyncFunc = (_ctx: object | Function) => {
-			const _ctxProto = Object.prototype.toString.call(_ctx);
-			return _ctxProto === '[object AsyncFunction]';
-		};
-
 		const isPromise = (_ctx: object | Function) => {
 			const _ctxProto = Object.prototype.toString.call(_ctx);
 			return _ctxProto === '[object Promise]';
@@ -493,12 +488,10 @@ export class Umzug<Ctx extends object = object> extends emittery<UmzugEvents<Ctx
 
 		let { context = {} as Ctx }: UmzugOptions<Ctx> = this.options;
 
-		if (isAsyncFunc(context)) {
-			context = await (context as () => Promise<Ctx>)();
-		} else if (isPromise(context)) {
+		if (isPromise(context)) {
 			context = await Promise.resolve(context as Promise<Ctx>);
 		} else if (typeof context === 'function') {
-			context = (context as () => Ctx)();
+			context = await (context as () => Promise<Ctx> | Ctx)();
 		}
 
 		return context;

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -481,9 +481,8 @@ export class Umzug<Ctx extends object = object> extends emittery<UmzugEvents<Ctx
 	}
 
 	private async getContext(): Promise<Ctx> {
-		const isPromise = (_ctx: object | Function) => {
-			const _ctxProto = Object.prototype.toString.call(_ctx);
-			return _ctxProto === '[object Promise]';
+		const isPromise = (_ctx: object | Function | PromiseLike<unknown>) => {
+			return 'then' in _ctx && typeof _ctx.then === 'function';
 		};
 
 		let { context = {} as Ctx }: UmzugOptions<Ctx> = this.options;

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -481,19 +481,8 @@ export class Umzug<Ctx extends object = object> extends emittery<UmzugEvents<Ctx
 	}
 
 	private async getContext(): Promise<Ctx> {
-		const isPromise = (_ctx: object | Function | PromiseLike<unknown>) => {
-			return 'then' in _ctx && typeof _ctx.then === 'function';
-		};
-
-		let { context = {} as Ctx }: UmzugOptions<Ctx> = this.options;
-
-		if (isPromise(context)) {
-			context = await Promise.resolve(context as Promise<Ctx>);
-		} else if (typeof context === 'function') {
-			context = await (context as () => Promise<Ctx> | Ctx)();
-		}
-
-		return context;
+		const { context = {} } = this.options;
+		return typeof context === 'function' ? context() : context;
 	}
 
 	/** helper for parsing input migrations into a callback returning a list of ready-to-run migrations */

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -99,11 +99,7 @@ describe('custom context', () => {
 			// before the actual migrations workflow begins.
 			// Eg: const externalData = await retrieveExternalData();
 			await sleep(100);
-
-			return {
-				// Eg: externalData,
-				innerValue: 'text',
-			};
+			return { innerValue: 'text' };
 		};
 
 		test(`context specified as a function`, async () => {


### PR DESCRIPTION
It often needs that we should do some preparation prior to context could be provided to migrations modules. It could be the initialization of database backend storages, etc. The old behavior keeps untouched, but this PR adds the advantage to use the asynchronous functions to retrieve context.