### PR TITLE
add txt storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,12 @@ Using `MongoDBStorage` will create a collection in your MongoDB database called 
 
 Detailed documentation for the options it can take are in the `MongoDBStorageConstructorOptions` TypeScript interface, which can be found in [src/storage/mongodb.ts](./src/storage/mongodb.ts).
 
+#### TXT Storage
+
+Using `TXTStorage` will create a txt file which will contain the log of all executed migrations. You can specify the path of the file. The default for that is `umzug.txt` in the working directory of the process.
+
+Detailed documentation for the options it can take are in the `TXTStorageConstructorOptions` Typescript interface, which can be found in [src/storage/txt.ts](./src/storage/txt.ts).
+
 #### Custom
 
 In order to use a custom storage, you can pass your storage instance to Umzug constructor.

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -4,4 +4,5 @@ export * from './json';
 export * from './memory';
 export * from './mongodb';
 export * from './sequelize';
+export * from './txt';
 // codegen:end

--- a/src/storage/txt.ts
+++ b/src/storage/txt.ts
@@ -1,0 +1,40 @@
+import jetpack = require('fs-jetpack');
+import { UmzugStorage } from './contract';
+
+const SEPARATOR = '\n';
+
+export interface TXTStorageConstructorOptions {
+	/**
+	Path to JSON file where the log is stored.
+
+	@default './umzug.txt'
+	*/
+	readonly path?: string;
+}
+
+export class TXTStorage implements UmzugStorage {
+	public readonly path: string;
+
+	constructor(options?: TXTStorageConstructorOptions) {
+		this.path = options?.path ?? jetpack.path(process.cwd(), 'umzug.txt');
+	}
+
+	async logMigration({ name }: { name: string }): Promise<void> {
+		const seeds = await this.executed();
+		return jetpack.writeAsync(this.path, [...seeds, name, ''].join(SEPARATOR));
+	}
+
+	async unlogMigration({ name }: { name: string }): Promise<void> {
+		const seeds = await this.executed();
+		const newContent = [...seeds.filter(seedName => seedName !== name), ''].join(SEPARATOR);
+
+		return jetpack.writeAsync(this.path, newContent);
+	}
+
+	async executed(): Promise<string[]> {
+		const content = await jetpack.readAsync(this.path);
+		const seeds = content ? content.split(SEPARATOR).filter(name => name !== '') : [];
+
+		return seeds;
+	}
+}

--- a/test/storage/txt.test.ts
+++ b/test/storage/txt.test.ts
@@ -1,0 +1,91 @@
+import path = require('path');
+import { expectTypeOf } from 'expect-type';
+import { fsSyncer } from 'fs-syncer';
+
+import { TXTStorage, UmzugStorage } from '../../src';
+
+describe('TXTStorage', () => {
+	describe('constructor', () => {
+		test('type', () => {
+			expectTypeOf(TXTStorage).toBeConstructibleWith();
+			expectTypeOf(TXTStorage).toBeConstructibleWith({});
+			expectTypeOf(TXTStorage).toBeConstructibleWith({ path: 'test.txt' });
+			expectTypeOf(TXTStorage).instance.toMatchTypeOf<UmzugStorage>();
+			expectTypeOf(TXTStorage).instance.toHaveProperty('path').toBeString();
+		});
+
+		test('default storage path', () => {
+			const storage = new TXTStorage();
+			expect(storage.path).toEqual(path.join(process.cwd(), 'umzug.txt'));
+		});
+	});
+
+	describe('logMigration', () => {
+		const syncer = fsSyncer(path.join(__dirname, '../generated/TXTStorage/logMigration'), {});
+		const storage = new TXTStorage({ path: path.join(syncer.baseDir, 'umzug.txt') });
+
+		beforeEach(syncer.sync);
+
+		test('adds entry', async () => {
+			await storage.logMigration({ name: 'seed-1.js' });
+
+			expect(syncer.read()).toEqual({
+				'umzug.txt': 'seed-1.js\n',
+			});
+		});
+
+		test(`doesn't dedupe`, async () => {
+			await storage.logMigration({ name: 'seed-1.js' });
+			await storage.logMigration({ name: 'seed-1.js' });
+
+			expect(syncer.read()).toEqual({
+				'umzug.txt': 'seed-1.js\nseed-1.js\n',
+			});
+		});
+	});
+
+	describe('unlogMigration', () => {
+		const syncer = fsSyncer(path.join(__dirname, '../generated/TXTStorage/unlogMigration'), {
+			'umzug.txt': 'seed-1.js\nseed-2.js\n',
+		});
+		const storage = new TXTStorage({ path: path.join(syncer.baseDir, 'umzug.txt') });
+
+		beforeEach(syncer.sync);
+
+		test('removes entry', async () => {
+			await storage.unlogMigration({ name: 'seed-1.js' });
+
+			expect(syncer.read()).toEqual({
+				'umzug.txt': 'seed-2.js\n',
+			});
+		});
+
+		test(`it does nothing when unlogging non-existent migration`, async () => {
+			await storage.unlogMigration({ name: 'does-not-exists.js' });
+
+			expect(syncer.read()).toEqual({
+				'umzug.txt': 'seed-1.js\nseed-2.js\n',
+			});
+		});
+	});
+
+	describe('executed', () => {
+		const syncer = fsSyncer(path.join(__dirname, '../generated/TXTStorage/executed'), {});
+		const storage = new TXTStorage({ path: path.join(syncer.baseDir, 'umzug.txt') });
+
+		beforeEach(syncer.sync);
+
+		test('returns empty array when no migrations are logged', async () => {
+			const executed = await storage.executed();
+
+			expect(executed).toEqual([]);
+		});
+
+		test('returns logged migration', async () => {
+			await storage.logMigration({ name: 'seed-1.js' });
+			const executed = await storage.executed();
+
+			expect(executed).toEqual(['seed-1.js']);
+		});
+	});
+});


### PR DESCRIPTION
Proposal for a txt storage, my main motivation to do this is that I was using the JSON storage but the git diffs are a little bit dirty because JSON format doesn't allow to have a trailing comma, with a plain txt having each seed log in a different line will solve the problem.

Example of a git diff using JSON vs txt format:

```diff
[
-   "seed-1.js"
+   "seed-1.js",
+   "seed-2.js"
]
```

```diff
 seed-1.js
+seed-2.js
```