### PR TITLE
fix #491. Fix MongoStorage `unlogMigration`

### DIFF
--- a/src/storage/mongodb.ts
+++ b/src/storage/mongodb.ts
@@ -54,7 +54,7 @@ export class MongoDBStorage implements UmzugStorage {
 	}
 
 	async unlogMigration({ name: migrationName }: { name: string }): Promise<void> {
-		await this.collection.removeOne({ migrationName });
+		await this.collection.deleteOne({ migrationName });
 	}
 
 	async executed(): Promise<string[]> {

--- a/test/storage/mongodb.test.ts
+++ b/test/storage/mongodb.test.ts
@@ -4,7 +4,7 @@ import { expectTypeOf } from 'expect-type';
 describe('MongoDBStorage', () => {
 	const mockCollection = {
 		insertOne: jest.fn(),
-		removeOne: jest.fn(),
+		deleteOne: jest.fn(),
 		find: jest.fn().mockReturnValue({
 			sort: jest.fn().mockReturnValue({
 				toArray: jest.fn().mockResolvedValue([{ migrationName: 'fake' }]),
@@ -81,8 +81,8 @@ describe('MongoDBStorage', () => {
 		test('adds entry to storage', async () => {
 			const storage = new MongoDBStorage({ collection: mockCollection });
 			await storage.unlogMigration({ name: 'm1.txt' });
-			expect(mockCollection.removeOne).toHaveBeenCalledTimes(1);
-			expect(mockCollection.removeOne).toHaveBeenCalledWith({
+			expect(mockCollection.deleteOne).toHaveBeenCalledTimes(1);
+			expect(mockCollection.deleteOne).toHaveBeenCalledWith({
 				migrationName: 'm1.txt',
 			});
 		});


### PR DESCRIPTION
fix #491. replace `removeOne` with `deleteOne`