### PR TITLE
Drop support for node <12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 10.x]
+        node-version: [14.x, 12.x]
         sequelize-version: [null, latest]
     steps:
     - uses: actions/checkout@v2
@@ -22,4 +22,4 @@ jobs:
     - run: npm run test -- --coverage
     - name: Coverage
       uses: codecov/codecov-action@v1
-      if: matrix.node-version == '12.x' && matrix.sequelize-version == null
+      if: matrix.node-version == '14.x' && matrix.sequelize-version == null

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 	},
 	"homepage": "https://github.com/sequelize/umzug",
 	"engines": {
-		"node": ">=10.0.0"
+		"node": ">=12"
 	},
 	"jest": {
 		"preset": "ts-jest",


### PR DESCRIPTION
@papb I'd like to do a major release of umzug v3. Theoretically it would be nice if some work was done to make sequelize-cli and umzug play nice together. But the API and CLI are both pretty stable (I've been using v3 beta in production at work for the best part of a year). There's no reason sequelize-cli shouldn't be able to use the API. It's not like we _can't_ go to v4 if we find there's an absolutely essential breaking change.

But before releasing v3, I think we should drop node 10. We'll be releasing in 2021, nobody should be on node 10 anymore (and if they are, they can just use umzug v2. They clearly like ancient tools).