### PR TITLE
chore: auto fix lint errors

### DIFF
--- a/examples/3.raw-sql/umzug.ts
+++ b/examples/3.raw-sql/umzug.ts
@@ -18,7 +18,7 @@ const getRawSqlClient = () => {
 export const migrator = new Umzug({
 	migrations: {
 		glob: ['migrations/*.sql', { cwd: __dirname }],
-		resolve: params => {
+		resolve(params) {
 			const downPath = path.join(path.dirname(params.path!), 'down', path.basename(params.path!));
 			return {
 				name: params.name,

--- a/examples/6.events/umzug.ts
+++ b/examples/6.events/umzug.ts
@@ -16,10 +16,10 @@ export const migrator = new Umzug({
 });
 
 const fakeApi = {
-	shutdownInternalService: async () => {
+	async shutdownInternalService() {
 		console.log('shutting down...');
 	},
-	restartInternalService: async () => {
+	async restartInternalService() {
 		console.log('restarting!');
 	},
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -239,10 +239,10 @@ export class CreateAction extends cli.CommandLineAction {
 	}
 }
 
-export interface CommandLineParserOptions {
+export type CommandLineParserOptions = {
 	toolFileName?: string;
 	toolDescription?: string;
-}
+};
 
 export class UmzugCLI extends cli.CommandLineParser {
 	constructor(readonly umzug: Umzug, commandLineParserOptions: CommandLineParserOptions = {}) {

--- a/src/file-locker.ts
+++ b/src/file-locker.ts
@@ -2,10 +2,10 @@ import fs = require('fs');
 import path = require('path');
 import { Umzug } from './umzug';
 
-export interface FileLockerOptions {
+export type FileLockerOptions = {
 	path: string;
 	fs?: typeof fs;
-}
+};
 
 /**
  * Simple locker using the filesystem. Only one lock can be held per file. An error will be thrown if the

--- a/src/storage/contract.ts
+++ b/src/storage/contract.ts
@@ -1,6 +1,6 @@
 import { MigrationParams } from '../types';
 
-export interface UmzugStorage<Ctx = unknown> {
+export type UmzugStorage<Ctx = unknown> = {
 	/**
 	 * Logs migration to be considered as executed.
 	 */
@@ -15,7 +15,7 @@ export interface UmzugStorage<Ctx = unknown> {
 	 * Gets list of executed migrations.
 	 */
 	executed: (meta: Pick<MigrationParams<Ctx>, 'context'>) => Promise<string[]>;
-}
+};
 
 export function isUmzugStorage(arg: Partial<UmzugStorage>): arg is UmzugStorage {
 	return (

--- a/src/storage/json.ts
+++ b/src/storage/json.ts
@@ -1,14 +1,14 @@
 import jetpack = require('fs-jetpack');
 import { UmzugStorage } from './contract';
 
-export interface JSONStorageConstructorOptions {
+export type JSONStorageConstructorOptions = {
 	/**
 	Path to JSON file where the log is stored.
 
 	@default './umzug.json'
 	*/
 	readonly path?: string;
-}
+};
 
 export class JSONStorage implements UmzugStorage {
 	public readonly path: string;

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -3,10 +3,10 @@ import { UmzugStorage } from './contract';
 export const memoryStorage = (): UmzugStorage => {
 	let executed: string[] = [];
 	return {
-		logMigration: async ({ name }) => {
+		async logMigration({ name }) {
 			executed.push(name);
 		},
-		unlogMigration: async ({ name }) => {
+		async unlogMigration({ name }) {
 			executed = executed.filter(n => n !== name);
 		},
 		executed: async () => [...executed],

--- a/src/storage/mongodb.ts
+++ b/src/storage/mongodb.ts
@@ -3,7 +3,7 @@ import { UmzugStorage } from './contract';
 
 type AnyObject = Record<string, any>;
 
-export interface MongoDBConnectionOptions {
+export type MongoDBConnectionOptions = {
 	/**
 	A connection to target database established with MongoDB Driver
 	*/
@@ -15,14 +15,14 @@ export interface MongoDBConnectionOptions {
 	@default 'migrations'
 	*/
 	readonly collectionName?: string;
-}
+};
 
-export interface MongoDBCollectionOptions {
+export type MongoDBCollectionOptions = {
 	/**
 	A reference to a MongoDB Driver collection
 	*/
 	readonly collection: AnyObject;
-}
+};
 
 export type MongoDBStorageConstructorOptions = MongoDBConnectionOptions | MongoDBCollectionOptions;
 

--- a/src/storage/sequelize.ts
+++ b/src/storage/sequelize.ts
@@ -2,13 +2,13 @@
 import { UmzugStorage } from './contract';
 import { SetRequired } from 'type-fest';
 
-interface ModelTempInterface extends ModelClass, Record<string, any> {}
+type ModelTempInterface = {} & ModelClass & Record<string, any>;
 
 /**
  * Minimal structure of a sequelize model, defined here to avoid a hard dependency.
  * The type expected is `import { Model } from 'sequelize'`
  */
-export interface ModelClass {
+export type ModelClass = {
 	tableName: string;
 	sequelize?: SequelizeType;
 	getTableName(): string;
@@ -16,22 +16,22 @@ export interface ModelClass {
 	findAll(options?: {}): Promise<any[]>;
 	create(options: {}): Promise<void>;
 	destroy(options: {}): Promise<void>;
-}
+};
 
 /**
  * Minimal structure of a sequelize model, defined here to avoid a hard dependency.
  * The type expected is `import { Sequelize } from 'sequelize'`
  */
-export interface SequelizeType {
+export type SequelizeType = {
 	getQueryInterface(): any;
 	isDefined(modelName: string): boolean;
 	model(modelName: string): any;
 	define(modelName: string, columns: {}, options: {}): {};
-}
+};
 
 type ModelClassType = ModelClass & (new (values?: object, options?: any) => ModelTempInterface);
 
-interface _SequelizeStorageConstructorOptions {
+type _SequelizeStorageConstructorOptions = {
 	/**
 	The configured instance of Sequelize. If omitted, it is inferred from the `model` option.
 	*/
@@ -83,7 +83,7 @@ interface _SequelizeStorageConstructorOptions {
 	@default false
 	*/
 	readonly timestamps?: boolean;
-}
+};
 
 export type SequelizeStorageConstructorOptions =
 	| SetRequired<_SequelizeStorageConstructorOptions, 'sequelize'>

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type Promisable<T> = T | PromiseLike<T>;
 export type LogFn = (message: Record<string, unknown>) => void;
 
 /** Constructor options for the Umzug class */
-export interface UmzugOptions<Ctx extends {} = Record<string, unknown>> {
+export type UmzugOptions<Ctx extends {} = Record<string, unknown>> = {
 	/** The migrations that the Umzug instance should perform */
 	migrations: InputMigrations<Ctx>;
 	/** A logging function. Pass `console` to use stdout, or pass in your own logger. Pass `undefined` explicitly to disable logging. */
@@ -35,21 +35,21 @@ export interface UmzugOptions<Ctx extends {} = Record<string, unknown>> {
 		 */
 		folder?: string;
 	};
-}
+};
 
 /** Serializeable metadata for a migration. The structure returned by the external-facing `pending()` and `executed()` methods. */
-export interface MigrationMeta {
+export type MigrationMeta = {
 	/** Name - this is used as the migration unique identifier within storage */
 	name: string;
 	/** An optional filepath for the migration. Note: this may be undefined, since not all migrations correspond to files on the filesystem */
 	path?: string;
-}
+};
 
-export interface MigrationParams<T> {
+export type MigrationParams<T> = {
 	name: string;
 	path?: string;
 	context: T;
-}
+};
 
 /** A callable function for applying or reverting a migration  */
 export type MigrationFn<T = unknown> = (params: MigrationParams<T>) => Promise<unknown>;
@@ -57,12 +57,12 @@ export type MigrationFn<T = unknown> = (params: MigrationParams<T>) => Promise<u
 /**
  * A runnable migration. Represents a migration object with an `up` function which can be called directly, with no arguments, and an optional `down` function to revert it.
  */
-export interface RunnableMigration<T> extends MigrationMeta {
+export type RunnableMigration<T> = {
 	/** The effect of applying the migration */
 	up: MigrationFn<T>;
 	/** The effect of reverting the migration */
 	down?: MigrationFn<T>;
-}
+} & MigrationMeta;
 
 /** Glob instructions for migration files */
 export type GlobInputMigrations<T> = {
@@ -140,11 +140,11 @@ export type MigrateDownOptions = MergeExclusive<
 >;
 
 /** Map of eventName -> eventData type, where the keys are the string events that are emitted by an umzug instances, and the values are the payload emitted with the corresponding event. */
-export interface UmzugEvents<Ctx> {
+export type UmzugEvents<Ctx> = {
 	migrating: MigrationParams<Ctx>;
 	migrated: MigrationParams<Ctx>;
 	reverting: MigrationParams<Ctx>;
 	reverted: MigrationParams<Ctx>;
 	beforeCommand: { command: string; context: Ctx };
 	afterCommand: { command: string; context: Ctx };
-}
+};

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -23,9 +23,9 @@ import {
 
 const globAsync = promisify(glob);
 
-interface MigrationErrorParams extends MigrationParams<unknown> {
+type MigrationErrorParams = {
 	direction: 'up' | 'down';
-}
+} & MigrationParams<unknown>;
 
 export class MigrationError extends errorCause.ErrorWithCause {
 	name = 'MigrationError';

--- a/test/sequelize.test.ts
+++ b/test/sequelize.test.ts
@@ -122,7 +122,7 @@ describe('v2 back compat', () => {
 		const umzug = new Umzug({
 			migrations: {
 				glob: ['migrations/*.js', { cwd: baseDir }],
-				resolve: ({ name, path, context }) => {
+				resolve({ name, path, context }) {
 					// umzug v2.x received context directly - this resolve function supports migrations written for v2
 					type MigrationFnV2 = (qi: QueryInterface) => Promise<unknown>;
 					// eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -275,10 +275,10 @@ describe('alternate migration inputs', () => {
 	test('up and down with step', async () => {
 		const umzug = new Umzug({
 			migrations: [
-				{ name: 'm1', up: async () => {} },
-				{ name: 'm2', up: async () => {} },
-				{ name: 'm3', up: async () => {} },
-				{ name: 'm4', up: async () => {} },
+				{ name: 'm1', async up() {} },
+				{ name: 'm2', async up() {} },
+				{ name: 'm3', async up() {} },
+				{ name: 'm4', async up() {} },
 			],
 			logger: undefined,
 		});
@@ -377,8 +377,8 @@ describe('alternate migration inputs', () => {
 	test('up and down return migration meta array', async () => {
 		const umzug = new Umzug({
 			migrations: [
-				{ name: 'm1', path: 'm1.sql', up: async () => {} },
-				{ name: 'm2', path: 'm2.sql', up: async () => {} },
+				{ name: 'm1', path: 'm1.sql', async up() {} },
+				{ name: 'm2', path: 'm2.sql', async up() {} },
 			],
 			logger: undefined,
 		});
@@ -400,7 +400,7 @@ describe('alternate migration inputs', () => {
 		const spy = jest.fn();
 
 		const umzug = new Umzug({
-			migrations: [{ name: 'm1', up: async () => {} }],
+			migrations: [{ name: 'm1', async up() {} }],
 			context: { someCustomSqlClient: {} },
 			storage: {
 				executed: async (...args) => spy('executed', ...args),
@@ -456,7 +456,7 @@ describe('alternate migration inputs', () => {
 		const spy = jest.fn();
 
 		const umzug = new Umzug({
-			migrations: context => {
+			migrations(context) {
 				expect(context).toEqual({ someCustomSqlClient: {} });
 				return [
 					{
@@ -486,13 +486,13 @@ describe('alternate migration inputs', () => {
 			migrations: [
 				{
 					name: 'm1',
-					up: async () => {},
+					async up() {},
 					down: async () => Promise.reject(new Error('Some cryptic failure')),
 				},
 				{
 					name: 'm2',
 					up: async () => Promise.reject(new Error('Some cryptic failure')),
-					down: async () => {},
+					async down() {},
 				},
 			],
 			logger: undefined,
@@ -512,13 +512,13 @@ describe('alternate migration inputs', () => {
 			migrations: [
 				{
 					name: 'm1',
-					up: async () => {},
+					async up() {},
 					down: async () => Promise.reject(new VError({ info: { extra: 'detail' } }, 'Some cryptic failure')),
 				},
 				{
 					name: 'm2',
 					up: async () => Promise.reject(new VError({ info: { extra: 'detail' } }, 'Some cryptic failure')),
-					down: async () => {},
+					async down() {},
 				},
 			],
 			logger: undefined,
@@ -552,7 +552,7 @@ describe('alternate migration inputs', () => {
 			migrations: [
 				{
 					name: 'm1',
-					up: async () => {},
+					async up() {},
 					// eslint-disable-next-line prefer-promise-reject-errors
 					down: async () => Promise.reject('Some cryptic failure'),
 				},
@@ -560,7 +560,7 @@ describe('alternate migration inputs', () => {
 					name: 'm2',
 					// eslint-disable-next-line prefer-promise-reject-errors
 					up: async () => Promise.reject('Some cryptic failure'),
-					down: async () => {},
+					async down() {},
 				},
 			],
 			logger: undefined,
@@ -750,8 +750,8 @@ describe('types', () => {
 		});
 		expectTypeOf(Umzug).toBeConstructibleWith({
 			migrations: [
-				{ name: 'm1', up: async () => {} },
-				{ name: 'm2', up: async () => {}, down: async () => {} },
+				{ name: 'm1', async up() {} },
+				{ name: 'm2', async up() {}, async down() {} },
 			],
 			logger: undefined,
 		});
@@ -880,9 +880,9 @@ describe('types', () => {
 		new Umzug({
 			migrations: {
 				glob: '*/*.ts',
-				resolve: params => {
+				resolve(params) {
 					expectTypeOf(params).toEqualTypeOf<{ name: string; path?: string; context: { someCustomSqlClient: {} } }>();
-					return { name: '', up: async () => {} };
+					return { name: '', async up() {} };
 				},
 			},
 			context: { someCustomSqlClient: {} },
@@ -1031,7 +1031,7 @@ describe('custom logger', () => {
 	test('uses custom logger', async () => {
 		const spy = jest.fn();
 		const umzug = new Umzug({
-			migrations: [{ name: 'm1', up: async () => {} }],
+			migrations: [{ name: 'm1', async up() {} }],
 			logger: {
 				info: spy,
 				warn: spy,


### PR DESCRIPTION
None of these updates are done manually, all are done by adding `--fix` to the eslint command specified in package.json.
Do note that this PR does not point towards `main` but to the branch of #566 