### PR TITLE
Fix false positive Confusing Ordering warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5936,9 +5936,9 @@
 			}
 		},
 		"node_modules/inquirer-autosubmit-prompt/node_modules/ansi-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+			"integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -6144,9 +6144,9 @@
 			}
 		},
 		"node_modules/inquirer-autosubmit-prompt/node_modules/strip-ansi/node_modules/ansi-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+			"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -9082,9 +9082,9 @@
 			}
 		},
 		"node_modules/log-update/node_modules/ansi-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+			"integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -17144,9 +17144,9 @@
 					"dev": true
 				},
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+					"integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
 					"dev": true
 				},
 				"ansi-styles": {
@@ -17309,9 +17309,9 @@
 					},
 					"dependencies": {
 						"ansi-regex": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"version": "4.1.1",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+							"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
 							"dev": true
 						}
 					}
@@ -19606,9 +19606,9 @@
 					"dev": true
 				},
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+					"integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
 					"dev": true
 				},
 				"cli-cursor": {

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -355,13 +355,6 @@ export class Umzug<Ctx extends object = object> extends emittery<UmzugEvents<Ctx
 			const existing = await this.migrations(context);
 			const last = existing[existing.length - 1];
 
-			const confusinglyOrdered = existing.find(e => e.path && path.basename(e.path) > fileBasename);
-			if (confusinglyOrdered && !options.allowConfusingOrdering) {
-				throw new Error(
-					`Can't create ${fileBasename}, since it's unclear if it should run before or after existing migration ${confusinglyOrdered.name}. Use allowConfusingOrdering to bypass this error.`
-				);
-			}
-
 			const folder = options.folder || this.options.create?.folder || (last?.path && path.dirname(last.path));
 
 			if (!folder) {
@@ -375,6 +368,18 @@ export class Umzug<Ctx extends object = object> extends emittery<UmzugEvents<Ctx
 			const toWrite = template(filepath);
 			if (toWrite.length === 0) {
 				toWrite.push([filepath, '']);
+			}
+
+			if (!options.allowConfusingOrdering) {
+				const confusinglyOrdered = existing.find(e => {
+					const existingPath = e.path;
+					return existingPath && toWrite.some(([newPath]) => existingPath > newPath);
+				});
+				if (confusinglyOrdered) {
+					throw new Error(
+						`Can't create ${fileBasename}, since it's unclear if it should run before or after existing migration ${confusinglyOrdered.name}. Use allowConfusingOrdering to bypass this error.`
+					);
+				}
 			}
 
 			toWrite.forEach(pair => {

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -363,23 +363,20 @@ export class Umzug<Ctx extends object = object> extends emittery<UmzugEvents<Ctx
 
 			const filepath = path.join(folder, fileBasename);
 
-			const template = this.options.create?.template ?? Umzug.defaultCreationTemplate;
-
-			const toWrite = template(filepath);
-			if (toWrite.length === 0) {
-				toWrite.push([filepath, '']);
-			}
-
 			if (!options.allowConfusingOrdering) {
-				const confusinglyOrdered = existing.find(e => {
-					const existingPath = e.path;
-					return existingPath && toWrite.some(([newPath]) => existingPath >= newPath);
-				});
+				const confusinglyOrdered = existing.find(e => e.path && e.path >= filepath);
 				if (confusinglyOrdered) {
 					throw new Error(
 						`Can't create ${fileBasename}, since it's unclear if it should run before or after existing migration ${confusinglyOrdered.name}. Use allowConfusingOrdering to bypass this error.`
 					);
 				}
+			}
+
+			const template = this.options.create?.template ?? Umzug.defaultCreationTemplate;
+
+			const toWrite = template(filepath);
+			if (toWrite.length === 0) {
+				toWrite.push([filepath, '']);
 			}
 
 			toWrite.forEach(pair => {

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -373,7 +373,7 @@ export class Umzug<Ctx extends object = object> extends emittery<UmzugEvents<Ctx
 			if (!options.allowConfusingOrdering) {
 				const confusinglyOrdered = existing.find(e => {
 					const existingPath = e.path;
-					return existingPath && toWrite.some(([newPath]) => existingPath > newPath);
+					return existingPath && toWrite.some(([newPath]) => existingPath >= newPath);
 				});
 				if (confusinglyOrdered) {
 					throw new Error(

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -123,7 +123,7 @@ describe('custom context', () => {
 				glob: ['*/*.js', { cwd: syncer.baseDir }],
 				resolve(params) {
 					const name = path.basename(path.dirname(params.path!));
-					return { name, async up() {} };
+					return { name, path: params.path, async up() {} };
 				},
 			},
 			logger: undefined,


### PR DESCRIPTION
Fixes #574 .

I've also noticed a vulnerabilities warning from NPM:

```
$ npm i

> umzug@3.2.1 prepare
> npm run build


> umzug@3.2.1 build
> del-cli lib && tsc -p tsconfig.lib.json


added 1031 packages, and audited 1032 packages in 40s

147 packages are looking for funding
  run `npm fund` for details

7 vulnerabilities (6 moderate, 1 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
```

I've run `npm audit fix` which updated some packages in `package-lock.json` and fixed the `1 high` vulnerability, but `6 moderate` still remain:

```
$ npm audit fix

changed 3 packages, and audited 1032 packages in 1s

147 packages are looking for funding
  run `npm fund` for details

# npm audit report

got  <11.8.5
Severity: moderate
Got allows a redirect to a UNIX socket - https://github.com/advisories/GHSA-pfrx-2q88-qq97
fix available via `npm audit fix --force`
Will install np@3.0.4, which is a breaking change
node_modules/got
node_modules/package-json/node_modules/got
  npm-name  <=6.0.1
  Depends on vulnerable versions of got
  node_modules/npm-name
    np  >=2.2.0
    Depends on vulnerable versions of npm-name
    Depends on vulnerable versions of update-notifier
    node_modules/np
  package-json  <=6.5.0
  Depends on vulnerable versions of got
  node_modules/package-json
    latest-version  0.2.0 - 5.1.0
    Depends on vulnerable versions of package-json
    node_modules/latest-version
      update-notifier  0.2.0 - 5.1.0
      Depends on vulnerable versions of latest-version
      node_modules/update-notifier

6 moderate severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force
```