### PR TITLE
Define custom prefixes for creating new migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,25 @@ const umzug = new Umzug({
 })
 ```
 
+You can also customize the format of the prefix added to migration file names:
+
+```js
+const umzug = new Umzug({
+	migrations: ...,
+	create: {
+		prefix: (prefix) => {
+			const base = new Date().toISOString().replace(/[-:]/g, "");
+			const prefixes = {
+				TIMESTAMP: base.split(".")[0],
+				DATE: base.split("T")[0],
+				NONE: '',
+			};
+			return prefixes[prefix];
+		}
+	}
+})
+```
+
 The create command includes some safety checks to make sure migrations aren't created with ambiguous ordering, and that they will be picked up by umzug when applying migrations. The first pair is expected to be the "up" migration file, and to be picked up by the `pending` command.
 
 Use `node migrator create --help` for more options:

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export type Promisable<T> = T | PromiseLike<T>;
 
 export type LogFn = (message: Record<string, unknown>) => void;
 
+export type MigrationPrefix = 'TIMESTAMP' | 'DATE' | 'NONE';
+
 /** Constructor options for the Umzug class */
 export type UmzugOptions<Ctx extends {} = Record<string, unknown>> = {
 	/** The migrations that the Umzug instance should perform */
@@ -34,6 +36,11 @@ export type UmzugOptions<Ctx extends {} = Record<string, unknown>> = {
 		 * in the same folder as the last existing migration. The value here can be overriden by passing `folder` when calling `create`.
 		 */
 		folder?: string;
+		/**
+		 * A function for generating custom prefixes for migration files when using `create`. If this is not specified the default date formats will
+		 * be used ("1970.01.01T00.00.00" for TIMESTAMP, "1970.01.01" for DATE and "" for NONE)
+		 */
+		prefix?: (prefix: MigrationPrefix) => string;
 	};
 };
 


### PR DESCRIPTION
This PR allows the user to specify a custom format for the filename prefix used when creating new migrations. This is currently only possible by returning a different filename from the `template` callback, but this doesn't happen until after ordering is resolved and so can easily lead to "confusing ordering" issues. This is primarily motivated by wanting to avoid dots in the filename timestamp, but could be useful for other reasons too such as using a counter instead of a timestamp.