### PR TITLE
Snowflake does not explicitly support collation in the same way as some other databases

### DIFF
--- a/src/storage/sequelize.ts
+++ b/src/storage/sequelize.ts
@@ -32,7 +32,7 @@ export type SequelizeType = {
 	};
 };
 
-const DIALECTS_WITH_CHARSET_AND_COLLATE = new Set(['mysql', 'mariadb', 'snowflake']);
+const DIALECTS_WITH_CHARSET_AND_COLLATE = new Set(['mysql', 'mariadb']);
 
 type ModelClassType = ModelClass & (new (values?: object, options?: any) => ModelTempInterface);
 


### PR DESCRIPTION
Snowflake does not explicitly support collation in the same way as some other databases.

Like it shows in [create table syntax](https://docs.snowflake.com/en/sql-reference/sql/create-table#syntax)
And in [collation specification](https://docs.snowflake.com/en/sql-reference/collation#label-collation-specification)

So this fix removes Snowflake from `DIALECTS_WITH_CHARSET_AND_COLLATE`