### PR TITLE
Fix DeprecationWarning for Sequelize V7

### DIFF
--- a/src/storage/sequelize.ts
+++ b/src/storage/sequelize.ts
@@ -117,7 +117,7 @@ export class SequelizeStorage implements UmzugStorage {
 		}
 
 		this.sequelize = options.sequelize ?? options.model.sequelize;
-		this.columnType = options.columnType ?? (this.sequelize.constructor as any).STRING;
+		this.columnType = options.columnType ?? (this.sequelize.constructor as any).DataTypes.STRING;
 		this.columnName = options.columnName ?? 'name';
 		this.timestamps = options.timestamps ?? false;
 		this.modelName = options.modelName ?? 'SequelizeMeta';


### PR DESCRIPTION
This PR is fixing DeprecationWarning for Sequelize V7 (currently alpha, warning [SEQUELIZE0010]): Accessing DataTypes on the Sequelize constructor is deprecated. Use the DataTypes object instead. 

Reference to [Sequelize V7 upgrade](https://sequelize.org/docs/v7/other-topics/upgrade/#new-deprecations).