### PR TITLE
fix: logMigration breaking on rerun ALLOW for mssql

### DIFF
--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -261,7 +261,9 @@ export class Umzug<Ctx extends object = object> extends emittery<UmzugEvents<Ctx
           throw new MigrationError({direction: 'up', ...params}, e)
         }
 
-        await this.storage.logMigration(params)
+        if (options.rerun !== RerunBehavior.ALLOW) {
+            await this.storage.logMigration(params);
+        }
 
         const duration = (Date.now() - start) / 1000
         this.logging({event: 'migrated', name: m.name, durationSeconds: duration})


### PR DESCRIPTION
When running the  `up`  command with `--name` and `--rerun ALLOW` arguments, the `logMigration` function is failing due to it trying to insert a record that already exists, resulting in a `ValidationError`.

This code checks for this and don't re-run the logMigration but you may want to update or do something else instead?