### PR TITLE
Fix "can not convert object to primitive" nonsence error message

### DIFF
--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -48,9 +48,14 @@ export class MigrationError extends errorCause.ErrorWithCause<unknown> {
   }
 
   private static errorString(cause: unknown) {
-    return cause instanceof Error
-      ? `Original error: ${cause.message}`
-      : `Non-error value thrown. See info for full props: ${cause as string}`
+    if (cause instanceof Error) return `Original error: ${cause.message}`
+    const msg = 'Non-error value thrown. See info for full props'
+    try {
+      return `${msg}: ${String(cause)}`
+    } catch {
+      //Null prototype object 'cause' would end up here
+      return msg
+    }
   }
 }
 

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -50,12 +50,9 @@ export class MigrationError extends errorCause.ErrorWithCause<unknown> {
   private static errorString(cause: unknown) {
     if (cause instanceof Error) return `Original error: ${cause.message}`
     const msg = 'Non-error value thrown. See info for full props'
-    try {
-      return `${msg}: ${String(cause)}`
-    } catch {
-      //Null prototype object 'cause' would end up here
-      return msg
-    }
+    if (typeof cause !== 'object' || (cause as {}).toString !== undefined) return `${msg}: ${String(cause)}`
+    //Null prototype object 'cause' would end up here
+    return msg
   }
 }
 

--- a/test/umzug.test.ts
+++ b/test/umzug.test.ts
@@ -685,7 +685,10 @@ describe('alternate migration inputs', () => {
           async up() {},
 
           async down() {
-            throw 'Some cryptic failure'
+            // This kind of error is thrown in MikroOrm migrations
+            const reallyCrypticFailure: any = Object.create(null)
+            reallyCrypticFailure.customText = 'Some cryptic failure'
+            throw reallyCrypticFailure
           },
         },
         {
@@ -705,7 +708,7 @@ describe('alternate migration inputs', () => {
     )
 
     await expect(umzug.down()).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Migration m1 (down) failed: Non-error value thrown. See info for full props: Some cryptic failure"`,
+      `"Migration m1 (down) failed: Non-error value thrown. See info for full props"`,
     )
   })
 


### PR DESCRIPTION
MikroOrm that uses umzug under the hood, throws custom errors in the form of objects derived from null (Null prototype objects) that are not handled correctly by errorString method, this result in confusing error message masking original error completely (nothing related to original error in stack trace)
This micro fix solves this and makes errorString more universal in handling such tricky objects.