### PR TITLE
Give the event emitter a name

### DIFF
--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -89,7 +89,9 @@ export class Umzug<Ctx extends object = object> extends emittery<UmzugEvents<Ctx
 
   /** creates a new Umzug instance */
   constructor(readonly options: UmzugOptions<Ctx>) {
-    super()
+    super({
+      debug: {name: 'umzug'},
+    })
 
     this.storage = verifyUmzugStorage(options.storage ?? new JSONStorage())
     this.migrations = this.getMigrationsResolver(this.options.migrations)


### PR DESCRIPTION
When the environment variable `DEBUG=emittery` is set, emittery logs events. I used this recently in a project and was surprised to see umzug logs. By specifying a name here, it'll be clearer to users where the logs come from :v: