### PR TITLE
Ugrade rushstack to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	],
 	"packageManager": "pnpm@8.10.2",
 	"dependencies": {
-		"@rushstack/ts-command-line": "^4.12.2",
+		"@rushstack/ts-command-line": "^5.3.3",
 		"emittery": "^0.13.0",
 		"pony-cause": "^2.1.4",
 		"tinyglobby": "^0.2.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@rushstack/ts-command-line':
-    specifier: ^4.12.2
-    version: 4.19.1(@types/node@20.12.7)
+    specifier: ^5.3.3
+    version: 5.3.3(@types/node@20.12.7)
   emittery:
     specifier: ^0.13.0
     version: 0.13.1
@@ -1148,8 +1148,8 @@ packages:
       - typescript
     dev: true
 
-  /@rushstack/node-core-library@4.0.2(@types/node@20.12.7):
-    resolution: {integrity: sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==}
+  /@rushstack/node-core-library@5.20.3(@types/node@20.12.7):
+    resolution: {integrity: sha512-95JgEPq2k7tHxhF9/OJnnyHDXfC9cLhhta0An/6MlkDsX2A6dTzDrTUG18vx4vjc280V0fi0xDH9iQczpSuWsw==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -1157,23 +1157,37 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.12.7
-      fs-extra: 7.0.1
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fs-extra: 11.3.4
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.8
       semver: 7.5.4
-      z-schema: 5.0.5
     dev: false
 
-  /@rushstack/terminal@0.10.0(@types/node@20.12.7):
-    resolution: {integrity: sha512-UbELbXnUdc7EKwfH2sb8ChqNgapUOdqcCIdQP4NGxBpTZV2sQyeekuK3zmfQSa/MN+/7b4kBogl2wq0vpkpYGw==}
+  /@rushstack/problem-matcher@0.2.1(@types/node@20.12.7):
+    resolution: {integrity: sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': 4.0.2(@types/node@20.12.7)
+      '@types/node': 20.12.7
+    dev: false
+
+  /@rushstack/terminal@0.22.3(@types/node@20.12.7):
+    resolution: {integrity: sha512-gHC9pIMrUPzAbBiI4VZMU7Q+rsCzb8hJl36lFIulIzoceKotyKL3Rd76AZ2CryCTKEg+0bnTj406HE5YY5OQvw==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+    dependencies:
+      '@rushstack/node-core-library': 5.20.3(@types/node@20.12.7)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@20.12.7)
       '@types/node': 20.12.7
       supports-color: 8.1.1
     dev: false
@@ -1186,10 +1200,10 @@ packages:
     resolution: {integrity: sha512-IBsPzcdZhzlMfYWEZxK87Zuqzu7gEOY5eB6KkkD9HfMHLXP2l/54jKI0Tmo5OcbrVa8aivwy0AlVcaPlobLwaQ==}
     dev: true
 
-  /@rushstack/ts-command-line@4.19.1(@types/node@20.12.7):
-    resolution: {integrity: sha512-J7H768dgcpG60d7skZ5uSSwyCZs/S2HrWP1Ds8d1qYAyaaeJmpmmLr9BVw97RjFzmQPOYnoXcKA4GkqDCkduQg==}
+  /@rushstack/ts-command-line@5.3.3(@types/node@20.12.7):
+    resolution: {integrity: sha512-c+ltdcvC7ym+10lhwR/vWiOhsrm/bP3By2VsFcs5qTKv+6tTmxgbVrtJ5NdNjANiV5TcmOZgUN+5KYQ4llsvEw==}
     dependencies:
-      '@rushstack/terminal': 0.10.0(@types/node@20.12.7)
+      '@rushstack/terminal': 0.22.3(@types/node@20.12.7)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -1952,6 +1966,28 @@ packages:
       indent-string: 5.0.0
     dev: true
 
+  /ajv-draft-04@1.0.0(ajv@8.18.0):
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.18.0
+    dev: false
+
+  /ajv-formats@3.0.1(ajv@8.18.0):
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.18.0
+    dev: false
+
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
@@ -1960,6 +1996,15 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
     dev: true
+
+  /ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+    dev: false
 
   /ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -2600,13 +2645,6 @@ packages:
     hasBin: true
     requiresBuild: true
     dev: true
-    optional: true
-
-  /commander@9.5.0:
-    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
-    engines: {node: ^12.20.0 || >=14}
-    requiresBuild: true
-    dev: false
     optional: true
 
   /concat-map@0.0.1:
@@ -3802,7 +3840,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
 
   /fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
@@ -3826,6 +3863,10 @@ packages:
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
+
+  /fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+    dev: false
 
   /fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -3962,13 +4003,13 @@ packages:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
     dev: true
 
-  /fs-extra@7.0.1:
-    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
-    engines: {node: '>=6 <7 || >=8'}
+  /fs-extra@11.3.4:
+    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
+    engines: {node: '>=14.14'}
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
+      jsonfile: 6.2.0
+      universalify: 2.0.1
     dev: false
 
   /fs-minipass@2.1.0:
@@ -5115,6 +5156,10 @@ packages:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
     dev: true
 
+  /json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    dev: false
+
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
@@ -5132,8 +5177,10 @@ packages:
     hasBin: true
     dev: true
 
-  /jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+  /jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+    dependencies:
+      universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
     dev: false
@@ -5262,14 +5309,6 @@ packages:
     dependencies:
       p-locate: 5.0.0
     dev: true
-
-  /lodash.get@4.4.2:
-    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
-    dev: false
-
-  /lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
-    dev: false
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -6529,6 +6568,11 @@ packages:
       jsesc: 0.5.0
     dev: true
 
+  /require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
     dev: true
@@ -7611,9 +7655,9 @@ packages:
     resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
     dev: true
 
-  /universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
+  /universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
     dev: false
 
   /update-browserslist-db@1.0.13(browserslist@4.23.0):
@@ -7697,6 +7741,7 @@ packages:
   /validator@13.11.0:
     resolution: {integrity: sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==}
     engines: {node: '>= 0.10'}
+    dev: true
 
   /verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -7989,18 +8034,6 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-  /z-schema@5.0.5:
-    resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
-    engines: {node: '>=8.0.0'}
-    hasBin: true
-    dependencies:
-      lodash.get: 4.4.2
-      lodash.isequal: 4.5.0
-      validator: 13.11.0
-    optionalDependencies:
-      commander: 9.5.0
-    dev: false
 
   /zod-package-json@1.0.3:
     resolution: {integrity: sha512-Mb6GzuRyUEl8X+6V6xzHbd4XV0au/4gOYrYP+CAfHL32uPmGswES+v2YqonZiW1NZWVA3jkssCKSU2knonm/aQ==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ export class UpAction extends cli.CommandLineAction {
       summary: 'Applies pending migrations',
       documentation: 'Performs all migrations. See --help for more options',
     })
+    this._params = UpAction._defineParameters(this)
   }
 
   private static _defineParameters(action: UpAction) {
@@ -39,11 +40,7 @@ export class UpAction extends cli.CommandLineAction {
     }
   }
 
-  onDefineParameters(): void {
-    this._params = UpAction._defineParameters(this)
-  }
-
-  async onExecute(): Promise<void> {
+  async onExecuteAsync(): Promise<void> {
     const {
       to: {value: to},
       step: {value: step},
@@ -86,6 +83,7 @@ export class DownAction extends cli.CommandLineAction {
       documentation:
         'Undoes previously-applied migrations. By default, undoes the most recent migration only. Use --help for more options. Useful in development to start from a clean slate. Use with care in production!',
     })
+    this._params = DownAction._defineParameters(this)
   }
 
   private static _defineParameters(action: DownAction) {
@@ -115,11 +113,7 @@ export class DownAction extends cli.CommandLineAction {
     }
   }
 
-  onDefineParameters(): void {
-    this._params = DownAction._defineParameters(this)
-  }
-
-  async onExecute(): Promise<void> {
+  async onExecuteAsync(): Promise<void> {
     const {
       to: {value: to},
       step: {value: step},
@@ -169,6 +163,7 @@ export class ListAction extends cli.CommandLineAction {
       summary: `Lists ${action} migrations`,
       documentation: `Prints migrations returned by \`umzug.${action}()\`. By default, prints migration names one per line.`,
     })
+    this._params = ListAction._defineParameters(this)
   }
 
   private static _defineParameters(action: cli.CommandLineAction) {
@@ -182,11 +177,7 @@ export class ListAction extends cli.CommandLineAction {
     }
   }
 
-  onDefineParameters(): void {
-    this._params = ListAction._defineParameters(this)
-  }
-
-  async onExecute(): Promise<void> {
+  async onExecuteAsync(): Promise<void> {
     const migrations = await this.umzug[this.action]()
     const formatted = this._params.json.value
       ? JSON.stringify(migrations, null, 2)
@@ -206,6 +197,7 @@ export class CreateAction extends cli.CommandLineAction {
       documentation:
         'Generates a placeholder migration file using a timestamp as a prefix. By default, mimics the last existing migration, or guesses where to generate the file if no migration exists yet.',
     })
+    this._params = CreateAction._defineParameters(this)
   }
 
   private static _defineParameters(action: cli.CommandLineAction) {
@@ -251,11 +243,7 @@ export class CreateAction extends cli.CommandLineAction {
     }
   }
 
-  onDefineParameters(): void {
-    this._params = CreateAction._defineParameters(this)
-  }
-
-  async onExecute(): Promise<void> {
+  async onExecuteAsync(): Promise<void> {
     await this.umzug
       .create({
         name: this._params.name.value,
@@ -299,6 +287,4 @@ export class UmzugCLI extends cli.CommandLineParser {
     this.addAction(new ListAction('executed', umzug))
     this.addAction(new CreateAction(umzug))
   }
-
-  onDefineParameters(): void {}
 }

--- a/src/umzug.ts
+++ b/src/umzug.ts
@@ -168,7 +168,7 @@ export class Umzug<Ctx extends object = object> extends emittery<UmzugEvents<Ctx
    */
   async runAsCLI(argv?: string[]): Promise<boolean> {
     const cli = this.getCli()
-    return cli.execute(argv)
+    return cli.executeAsync(argv)
   }
 
   /** Get the list of migrations which have already been applied */

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -40,7 +40,7 @@ describe('cli from instance', () => {
   test('cli', async () => {
     /** run the cli with the specified args, then return the executed migration names */
     const runCli = async (argv: string[]) => {
-      await new UmzugCLI(umzug).executeWithoutErrorHandling(argv)
+      await new UmzugCLI(umzug).executeWithoutErrorHandlingAsync(argv)
       return (await umzug.executed()).map(e => e.name)
     }
 
@@ -246,7 +246,7 @@ describe('create migration file', () => {
     const runCLI = async (argv: string[]) => {
       const migrationsBefore = (syncer.read() as Record<string, any>).migrations
 
-      await new UmzugCLI(umzug).executeWithoutErrorHandling(argv)
+      await new UmzugCLI(umzug).executeWithoutErrorHandlingAsync(argv)
       const migrationsAfter = (syncer.read() as Record<string, any>).migrations
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       Object.keys(migrationsBefore || {}).forEach(k => delete migrationsAfter[k])
@@ -377,7 +377,7 @@ describe('create migration file', () => {
     const runCLI = async (argv: string[]) => {
       const migrationsBefore = (syncer.read() as Record<string, any>).migrations
 
-      await new UmzugCLI(umzug).executeWithoutErrorHandling(argv)
+      await new UmzugCLI(umzug).executeWithoutErrorHandlingAsync(argv)
       const migrationsAfter = (syncer.read() as Record<string, any>).migrations
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       Object.keys(migrationsBefore || {}).forEach(k => delete migrationsAfter[k])
@@ -427,7 +427,7 @@ describe('create migration file', () => {
 
     /** run the cli with the specified args */
     const runCLI = async (argv: string[]) => {
-      await new UmzugCLI(umzug).executeWithoutErrorHandling(argv)
+      await new UmzugCLI(umzug).executeWithoutErrorHandlingAsync(argv)
     }
 
     await expect(runCLI(['create', '--name', 'm1.sql'])).rejects.toMatchInlineSnapshot(


### PR DESCRIPTION
Upgrade `@rushstack/ts-command-line` to v5 to resolve security vulnerability ([CVE-2025-69873](https://github.com/advisories/GHSA-2g4f-4pwh-qvx6)) in transitive dependency of v4. Resolves #715.

- Rename deprecated functions removed in `@rushstack/ts-command-line` v5 ([changelog](https://github.com/microsoft/rushstack/blob/main/libraries/ts-command-line/CHANGELOG.md#500)).
- Replace `onDefineParameters` with definition in constructor as suggested in [the commit it was deprecated](https://github.com/microsoft/rushstack/pull/4716/changes#diff-417341a238c3974374d7b887b9fb03471eb799df2acf5d0115f8bfae714a7a22).